### PR TITLE
Make `nix run .` work on Nix 2.8+

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,6 @@
         apps.process-compose = flake-utils.lib.mkApp {
           drv = self.packages."${system}".process-compose;
         };
-        defaultApp = self.apps."${system}".process-compose;
+        apps.default = self.apps."${system}".process-compose;
       });
 }


### PR DESCRIPTION
Yay, breaking changes on minor version updates!
Cause: https://github.com/NixOS/nix/issues/6448#issuecomment-1132855605

I'll try submitting this package to nixpkgs, so the maintanence of the build instructions can be done separately. Until then this makes trying out process-compose for the latest nix users a breeze.