### PR TITLE
Install shell completions automatically via Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, installShellFiles, ... }:
 
 pkgs.buildGoModule rec {
   pname = "process-compose";
@@ -6,9 +6,18 @@ pkgs.buildGoModule rec {
   src = ./.;
   ldflags = [ "-X main.version=v${version}" ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   vendorSha256 = "RqPH8gm8K8sLuRl4FTpGeitS++t3ygAgZ6OMvBCsCB8=";
 
-  postInstall = "mv $out/bin/{src,process-compose}";
+  postInstall = ''
+    mv $out/bin/{src,process-compose}
+
+    installShellCompletion --cmd process-compose \
+      --bash <($out/bin/process-compose completion bash) \
+      --zsh <($out/bin/process-compose completion zsh) \
+      --fish <($out/bin/process-compose completion fish)
+  '';
 
   meta = with lib; {
     description =
@@ -17,5 +26,6 @@ pkgs.buildGoModule rec {
     license = licenses.asl20;
     mainProgram = "process-compose";
   };
+
   doCheck = false; # it takes ages to run the tests
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655273078,
-        "narHash": "sha256-jlcD35mFKn7CQHUgUa0E79QrS5+5A+/Gh3BI2y/PC3U=",
+        "lastModified": 1666837999,
+        "narHash": "sha256-hI7+s1UVDsJNqNn9UGV6xTBGqMC4dqOyVpeDf+su7JU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29399e5ad1660668b61247c99894fc2fb97b4e74",
+        "rev": "1c6eb4876f71e8903ae9f73e6adf45fdbebc0292",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
[kszabo@paks3:~/projects/process-compose]$ process-compose
process-compose: command not found

[kszabo@paks3:~/projects/process-compose]$ nix profile install .

[kszabo@paks3:~/projects/process-compose]$ process-compose 
completion  (Generate the autocompletion script for the specified shell)  help        (Help about any command)                                      process     (Execute operations on available processes)

[kszabo@paks3:~/projects/process-compose]$ process-compose process 
list     (List available processes)  restart  (Restart a process)         start    (Start a process)           stop     (Stop a running process)   
```
Also bumped the flake.lock file so the latest dependencies do not complain about Go <1.18