### PR TITLE
Rework nix instructions now that nixpkgs has it

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ process-compose -f /path/to/process-compose.yaml
 - If you have the Nix package manager installed with Flake support, just run:
 
 ```sh
-nix run github:F1bonacc1/process-compose
+# to use the latest binary release
+nix run nixpkgs/master#process-compose -- --help
+
+# or to compile from the latest source
+nix run github:F1bonacc1/process-compose -- --help
 ```
 
 ### Documentation

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
-{ config, lib, pkgs, installShellFiles, ... }:
+{ buildGoModule, config, lib, pkgs, installShellFiles, version ? "latest" }:
 
-pkgs.buildGoModule rec {
+buildGoModule {
   pname = "process-compose";
-  version = "0.24.1";
+  version = version;
   src = ./.;
   ldflags = [ "-X main.version=v${version}" ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,9 @@
         };
       in {
         overlays.default = final: prev: {
-          process-compose = final.callPackage ./default.nix { };
+          process-compose = final.callPackage ./default.nix {
+            version = self.shortRev or "dirty";
+          };
         };
         overlay = self.overlays.default;
         packages = { inherit (pkgs) process-compose; };


### PR DESCRIPTION
now that this project is packaged in the [main nixpkgs repostitory](https://github.com/NixOS/nixpkgs/pull/201877)
the need for instructing people to compile from source is unnecessary.

I'm also proposing changes to include process-compose as a built-in component in this project:
https://devenv.sh/
https://github.com/cachix/devenv/issues/78

The above would solve problems like https://github.com/F1bonacc1/process-compose/issues/14
and provide nice common service descriptions for common architectural components (postgres/kafka/redis/etc.).

Might be worth mentioning in the README.md once the above issue is resolved.