### PR TITLE
Added version command - prints process-compose version and build info

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,11 @@ builds:
         goarch: arm
     dir: src
     ldflags:
-      - -X github.com/f1bonacc1/process-compose/src/config.Version={{.Tag}} -X github.com/f1bonacc1/process-compose/src/config.CheckForUpdates=true -s -w
+      - -X github.com/f1bonacc1/process-compose/src/config.Version={{.Tag}}
+      - -X github.com/f1bonacc1/process-compose/src/config.CheckForUpdates=true
+      - -X github.com/f1bonacc1/process-compose/src/config.Commit={{.ShortCommit}}
+      - -X github.com/f1bonacc1/process-compose/src/config.Date={{.Date}}
+      - -s -w
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
       - -X github.com/f1bonacc1/process-compose/src/config.Version={{.Tag}}
       - -X github.com/f1bonacc1/process-compose/src/config.CheckForUpdates=true
       - -X github.com/f1bonacc1/process-compose/src/config.Commit={{.ShortCommit}}
-      - -X github.com/f1bonacc1/process-compose/src/config.Date={{.Date}}
+      - -X github.com/f1bonacc1/process-compose/src/config.Date={{.CommitDate}}
       - -s -w
 archives:
   - replacements:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME=process-compose
 RM=rm
 VERSION = $(shell git describe --abbrev=0)
 GIT_REV    ?= $(shell git rev-parse --short HEAD)
-DATE       ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+DATE       ?= $(shell TZ=UTC0 git show --quiet --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format="%cd")
 NUMVER = $(shell echo ${VERSION} | cut -d"v" -f 2)
 PKG = github.com/f1bonacc1/${NAME}
 SHELL := /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 NAME=process-compose
 RM=rm
 VERSION = $(shell git describe --abbrev=0)
+GIT_REV    ?= $(shell git rev-parse --short HEAD)
+DATE       ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 NUMVER = $(shell echo ${VERSION} | cut -d"v" -f 2)
-PKG = github.com/f1bonacc1/process-compose
+PKG = github.com/f1bonacc1/${NAME}
 SHELL := /bin/bash
-LD_FLAGS := -ldflags="-X ${PKG}/src/config.Version=${VERSION} -X ${PKG}/src/config.CheckForUpdates=true -s -w"
-
+LD_FLAGS := -ldflags="-X ${PKG}/src/config.Version=${VERSION} \
+            -X ${PKG}/src/config.CheckForUpdates=true \
+            -X ${PKG}/src/config.Commit=${GIT_REV} \
+            -X ${PKG}/src/config.Date=${DATE} \
+            -s -w"
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
 	RM = cmd /C del /Q /F
@@ -58,3 +63,5 @@ clean:
 release:
 	source exports
 	goreleaser release --rm-dist --skip-validate
+snapshot:
+	goreleaser release --snapshot --rm-dist

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,18 @@
-{ buildGoModule, config, lib, pkgs, installShellFiles, version ? "latest" }:
+{ buildGoModule, config, lib, pkgs, installShellFiles, date, commit }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "process-compose";
-  version = version;
+  version = "0.29.1";
+  pkg = "github.com/f1bonacc1/process-compose/src/config";
+
   src = ./.;
-  ldflags = [ "-X github.com/f1bonacc1/process-compose/src/config.Version=v${version} -s -w" ];
+  ldflags = [
+    "-X ${pkg}.Version=v${version}"
+    "-X ${pkg}.Date=${date}"
+    "-X ${pkg}.Commit=${commit}"
+    "-s"
+    "-w"
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -21,9 +29,9 @@ buildGoModule {
   '';
 
   meta = with lib; {
-    description =
-      "Process Compose is like docker-compose, but for orchestrating a suite of processes, not containers.";
+    description = "A simple and flexible scheduler and orchestrator to manage non-containerized applications";
     homepage = "https://github.com/F1bonacc1/process-compose";
+    changelog = "https://github.com/F1bonacc1/process-compose/releases/tag/v${version}";
     license = licenses.asl20;
     mainProgram = "process-compose";
   };

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,13 @@
 { buildGoModule, config, lib, pkgs, installShellFiles, date, commit }:
 
+let pkg = "github.com/f1bonacc1/process-compose/src/config";
+in
 buildGoModule rec {
   pname = "process-compose";
   version = "0.29.1";
-  pkg = "github.com/f1bonacc1/process-compose/src/config";
 
-  src = ./.;
+
+  src = lib.cleanSource ./.;
   ldflags = [
     "-X ${pkg}.Version=v${version}"
     "-X ${pkg}.Date=${date}"

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666837999,
-        "narHash": "sha256-hI7+s1UVDsJNqNn9UGV6xTBGqMC4dqOyVpeDf+su7JU=",
+        "lastModified": 1671971468,
+        "narHash": "sha256-dbToieyk3ym62lpO1ZZSPN+az/sBMmP05VAJcbb5PkM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c6eb4876f71e8903ae9f73e6adf45fdbebc0292",
+        "rev": "266927206388a73cb3dcfdc9bce73a381e3e1faf",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
       in {
         overlays.default = final: prev: {
           process-compose = final.callPackage ./default.nix {
-            version = self.shortRev or "dirty";
+            #version = self.shortRev or "dirty";
+            date = self.lastModifiedDate;
+            commit = self.shortRev or "dirty";
           };
         };
         overlay = self.overlays.default;

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     "Process Compose is like docker-compose, but for orchestrating a suite of processes, not containers.";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/f1bonacc1/process-compose/src/config"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version and build info",
+	Run: func(cmd *cobra.Command, args []string) {
+		printVersion()
+	},
+}
+
+func printVersion() {
+	format := "%-15s %s\n"
+	fmt.Println("Process Compose")
+	fmt.Printf(format, "Version:", config.Version)
+	fmt.Printf(format, "Commit:", config.Commit)
+	fmt.Printf(format, "Date (UTC):", config.Date)
+	fmt.Printf(format, "License:", config.License)
+	fmt.Println("\nWritten by Eugene Berger")
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -9,8 +9,13 @@ import (
 	"path/filepath"
 )
 
-var Version = "undefined"
-var CheckForUpdates = "false"
+var (
+	Version         = "undefined"
+	Commit          = "undefined"
+	Date            = "undefined"
+	CheckForUpdates = "false"
+	License         = "Apache-2.0"
+)
 
 const (
 	pcConfigEnv  = "PROC_COMP_CONFIG"


### PR DESCRIPTION
Hi @thenonameguy 

I was trying to add a version info command that prints the following output:
```
Version:        v0.29.1
Commit:         00a3211
Date (UTC):     2022-12-24T21:19:13Z
```
I did some changes to `default.nix` and `flake.nix`, but it still doesn't work as expected:
```
Version:        v0.29.1
Commit:         dirty
Date (UTC):     20221224212048
```
Can you please give me a hint or send me to the documentation on how to do it properly?
Also, I made some changes to `default.nix` to make it more like: 
https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/process-compose/default.nix

Can you please confirm that it's indeed the right direction?

Thanks!