### PR TITLE
Escape the TUI log lines in ANSI color mode

### DIFF
--- a/src/tui/log-viewer.go
+++ b/src/tui/log-viewer.go
@@ -55,7 +55,7 @@ func (l *LogView) WriteString(line string) (n int, err error) {
 	l.mx.Lock()
 	defer l.mx.Unlock()
 	if l.useAnsi {
-		return l.buffer.WriteString(line + "\n")
+		return l.buffer.WriteString(tview.Escape(line) + "\n")
 	}
 	if strings.Contains(strings.ToLower(line), "error") {
 		return fmt.Fprintf(l.buffer, "[deeppink]%s[-:-:-]\n", tview.Escape(line))


### PR DESCRIPTION
This PR escapes the log line in the `useAnsi` branch of `LogView.WriteString`. Without this escape, substrings that match `[\w+]` are interpreted by regions and cause display issues.