### PR TITLE
feat: availability.exit_on_end

### DIFF
--- a/src/app/project_runner.go
+++ b/src/app/project_runner.go
@@ -121,7 +121,8 @@ func (p *ProjectRunner) waitIfNeeded(process types.ProcessConfig) error {
 }
 
 func (p *ProjectRunner) onProcessEnd(exitCode int, procConf types.ProcessConfig) {
-	if exitCode != 0 && procConf.RestartPolicy.Restart == types.RestartPolicyExitOnFailure {
+	if (exitCode != 0 && procConf.RestartPolicy.Restart == types.RestartPolicyExitOnFailure) ||
+		procConf.RestartPolicy.ExitOnEnd {
 		p.ShutDownProject()
 		p.exitCode = exitCode
 	}

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -85,6 +85,7 @@ type RestartPolicyConfig struct {
 	Restart        string `yaml:",omitempty"`
 	BackoffSeconds int    `yaml:"backoff_seconds,omitempty"`
 	MaxRestarts    int    `yaml:"max_restarts,omitempty"`
+	ExitOnEnd      bool   `yaml:"exit_on_end,omitempty"`
 }
 
 type ShutDownParams struct {


### PR DESCRIPTION
a bool flag, if set to true, shuts down all processes once
given process ends (regardless of exit code)

this can be used together with `availability.restart = on_failure` to
have the process restarted on failure and only exit PC on success

closes #77