### PR TITLE
bugfix: fix definition of flake overlays output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,26 +7,28 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ self.overlays."${system}".default ];
         };
       in {
-        overlays.default = final: prev: {
-          process-compose = final.callPackage ./default.nix {
-            #version = self.shortRev or "dirty";
-            date = self.lastModifiedDate;
-            commit = self.shortRev or "dirty";
-          };
-        };
-        overlay = self.overlays.default;
         packages = { inherit (pkgs) process-compose; };
         defaultPackage = self.packages."${system}".process-compose;
         apps.process-compose = flake-utils.lib.mkApp {
           drv = self.packages."${system}".process-compose;
         };
         apps.default = self.apps."${system}".process-compose;
-      });
+      })
+    ) // {
+      overlays.default = final: prev: {
+        process-compose = final.callPackage ./default.nix {
+          #version = self.shortRev or "dirty";
+          date = self.lastModifiedDate;
+          commit = self.shortRev or "dirty";
+        };
+      };
+    }
+  ;
 }


### PR DESCRIPTION
overlays should not be defined per-system (see: https://discourse.nixos.org/t/how-to-consume-a-eachdefaultsystem-flake-overlay/19420/3)
also, overlay (singular) is not an official output
so we keep overlays.default only

I'm working on a project which doesn't use flakes yet so prefer to consume
via an overlay :)