### PR TITLE
implement process entrypoint and run cmd

### DIFF
--- a/src/app/commander_interface.go
+++ b/src/app/commander_interface.go
@@ -15,4 +15,5 @@ type Commander interface {
 	StderrPipe() (io.ReadCloser, error)
 	Stop(int, bool) error
 	SetCmdArgs()
+	AttachIo()
 }

--- a/src/app/system_test.go
+++ b/src/app/system_test.go
@@ -28,7 +28,7 @@ func TestSystem_TestFixtures(t *testing.T) {
 				t.Errorf(err.Error())
 				return
 			}
-			runner, err := NewProjectRunner(project, []string{}, false)
+			runner, err := NewProjectRunner(project, []string{}, false, "", []string{})
 			if err != nil {
 				t.Errorf(err.Error())
 				return
@@ -48,7 +48,7 @@ func TestSystem_TestComposeWithLog(t *testing.T) {
 			t.Errorf(err.Error())
 			return
 		}
-		runner, err := NewProjectRunner(project, []string{}, false)
+		runner, err := NewProjectRunner(project, []string{}, false, "", []string{})
 		if err != nil {
 			t.Errorf(err.Error())
 			return
@@ -81,7 +81,7 @@ func TestSystem_TestComposeChain(t *testing.T) {
 			t.Errorf(err.Error())
 			return
 		}
-		runner, err := NewProjectRunner(project, []string{}, false)
+		runner, err := NewProjectRunner(project, []string{}, false, "", []string{})
 		if err != nil {
 			t.Errorf(err.Error())
 			return
@@ -117,7 +117,7 @@ func TestSystem_TestComposeChainExit(t *testing.T) {
 			t.Errorf(err.Error())
 			return
 		}
-		runner, err := NewProjectRunner(project, []string{}, false)
+		runner, err := NewProjectRunner(project, []string{}, false, "", []string{})
 		if err != nil {
 			t.Errorf(err.Error())
 			return
@@ -162,7 +162,7 @@ func TestSystem_TestComposeScale(t *testing.T) {
 			t.Errorf(err.Error())
 			return
 		}
-		runner, err := NewProjectRunner(project, []string{}, false)
+		runner, err := NewProjectRunner(project, []string{}, false, "", []string{})
 		if err != nil {
 			t.Errorf(err.Error())
 			return

--- a/src/cmd/project_runner.go
+++ b/src/cmd/project_runner.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func getProjectRunner(process []string, noDeps bool) *app.ProjectRunner {
+func getProjectRunner(process []string, noDeps bool, mainProcess string, mainProcessArgs []string) *app.ProjectRunner {
 	if *pcFlags.HideDisabled {
 		opts.AddAdmitter(&admitter.DisabledProcAdmitter{})
 	}
@@ -23,7 +23,7 @@ func getProjectRunner(process []string, noDeps bool) *app.ProjectRunner {
 		log.Fatal().Msg(err.Error())
 	}
 
-	runner, err := app.NewProjectRunner(project, process, noDeps)
+	runner, err := app.NewProjectRunner(project, process, noDeps, mainProcess, mainProcessArgs)
 	if err != nil {
 		fmt.Println(err)
 		log.Fatal().Msg(err.Error())

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -34,7 +34,7 @@ func run(cmd *cobra.Command, args []string) error {
 	defer func() {
 		_ = logFile.Close()
 	}()
-	runner := getProjectRunner([]string{}, false)
+	runner := getProjectRunner([]string{}, false, "", []string{})
 	api.StartHttpServer(!*pcFlags.Headless, *pcFlags.PortNum, runner)
 	runProject(runner)
 	return nil

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -10,7 +10,7 @@ import (
 // runCmd represents the up command
 var runCmd = &cobra.Command{
 	Use:   "run PROCESS [flags] -- [process_args]",
-	Short: "Run PROCESS in the foreground, and it's dependencies in the background",
+	Short: "Run PROCESS in the foreground, and its dependencies in the background",
 	Long: `Run selected process with std(in|out|err) attached, while other processes run in the background.
 Command line arguments, provided after --, are passed to the PROCESS.`,
 	Args: cobra.MinimumNArgs(1),

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"github.com/f1bonacc1/process-compose/src/api"
+	"github.com/spf13/cobra"
+)
+
+// runCmd represents the up command
+var runCmd = &cobra.Command{
+	Use:   "run PROCESS [flags] -- [process_args]",
+	Short: "Run PROCESS in the foreground, and it's dependencies in the background",
+	Long: `Run selected process with std(in|out|err) attached, while other processes run in the background.
+Command line arguments, provided after --, are passed to the PROCESS.`,
+	Args: cobra.MinimumNArgs(1),
+	// Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		*pcFlags.Headless = false
+
+		processName := args[0]
+
+		if len(args) > 1 {
+			argsLenAtDash := cmd.ArgsLenAtDash()
+			if argsLenAtDash != 1 {
+				message := "Extra positional arguments provided! To pass args to PROCESS, separate them from process-compose arguments with: --"
+				fmt.Println(message)
+				os.Exit(1)
+			}
+			args = args[argsLenAtDash:]
+		} else {
+			// Clease args as they will contain the processName
+			args = []string{}
+		}
+
+		runner := getProjectRunner(
+			[]string{processName},
+			*pcFlags.NoDependencies,
+			processName,
+			args,
+		)
+
+		api.StartHttpServer(false, *pcFlags.PortNum, runner)
+		runProject(runner)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+
+	runCmd.Flags().BoolVarP(pcFlags.NoDependencies, "no-deps", "", *pcFlags.NoDependencies, "don't start dependent processes")
+	runCmd.Flags().AddFlag(rootCmd.Flags().Lookup("config"))
+
+}

--- a/src/cmd/up.go
+++ b/src/cmd/up.go
@@ -14,7 +14,7 @@ var upCmd = &cobra.Command{
 If one or more process names are passed as arguments,
 will start them and their dependencies only`,
 	Run: func(cmd *cobra.Command, args []string) {
-		runner := getProjectRunner(args, *pcFlags.NoDependencies)
+		runner := getProjectRunner(args, *pcFlags.NoDependencies, "", []string{})
 		api.StartHttpServer(!*pcFlags.Headless, *pcFlags.PortNum, runner)
 		runProject(runner)
 	},

--- a/src/command/command.go
+++ b/src/command/command.go
@@ -8,9 +8,10 @@ import (
 	"runtime"
 )
 
-func BuildCommandShellArg(shell ShellConfig, cmd string) *CmdWrapper {
+
+func BuildCommand(cmd string, args []string) *CmdWrapper {
 	return &CmdWrapper{
-		cmd: exec.Command(shell.ShellCommand, shell.ShellArgument, cmd),
+		cmd: exec.Command(cmd, args...),
 	}
 	//return NewMockCommand()
 }

--- a/src/command/command_wrapper.go
+++ b/src/command/command_wrapper.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"io"
+	"os"
 	"os/exec"
 )
 
@@ -35,6 +36,12 @@ func (c *CmdWrapper) StdoutPipe() (io.ReadCloser, error) {
 
 func (c *CmdWrapper) StderrPipe() (io.ReadCloser, error) {
 	return c.cmd.StderrPipe()
+}
+
+func (c *CmdWrapper) AttachIo() () {
+	c.cmd.Stdin = os.Stdin
+	c.cmd.Stdout = os.Stdout
+	c.cmd.Stderr = os.Stderr
 }
 
 func (c *CmdWrapper) SetEnv(env []string) {

--- a/src/loader/merger_test.go
+++ b/src/loader/merger_test.go
@@ -8,13 +8,11 @@ import (
 )
 
 func getBaseProcess() *types.ProcessConfig {
-	command := "command"
-
 	return &types.ProcessConfig{
 		Name:        "proc1",
 		Disabled:    false,
 		IsDaemon:    false,
-		Command:     &command,
+		Command:     "command",
 		LogLocation: "",
 		Environment: types.Environment{
 			"k1=v1",
@@ -59,13 +57,11 @@ func getBaseProcess() *types.ProcessConfig {
 }
 
 func getOverrideProcess() *types.ProcessConfig {
-	command := "override command"
-
 	return &types.ProcessConfig{
 		Name:        "proc1",
 		Disabled:    false,
 		IsDaemon:    false,
-		Command:     &command,
+		Command:     "override command",
 		LogLocation: "",
 		Environment: types.Environment{
 			"k0=v0",
@@ -124,13 +120,11 @@ func getOverrideProcess() *types.ProcessConfig {
 }
 
 func getMergedProcess() *types.ProcessConfig {
-	command := "override command"
-
 	return &types.ProcessConfig{
 		Name:        "proc1",
 		Disabled:    false,
 		IsDaemon:    false,
-		Command:     &command,
+		Command:     "override command",
 		LogLocation: "",
 		Environment: types.Environment{
 			"k0=v0",

--- a/src/loader/merger_test.go
+++ b/src/loader/merger_test.go
@@ -8,11 +8,13 @@ import (
 )
 
 func getBaseProcess() *types.ProcessConfig {
+	command := "command"
+
 	return &types.ProcessConfig{
 		Name:        "proc1",
 		Disabled:    false,
 		IsDaemon:    false,
-		Command:     "command",
+		Command:     &command,
 		LogLocation: "",
 		Environment: types.Environment{
 			"k1=v1",
@@ -57,11 +59,13 @@ func getBaseProcess() *types.ProcessConfig {
 }
 
 func getOverrideProcess() *types.ProcessConfig {
+	command := "override command"
+
 	return &types.ProcessConfig{
 		Name:        "proc1",
 		Disabled:    false,
 		IsDaemon:    false,
-		Command:     "override command",
+		Command:     &command,
 		LogLocation: "",
 		Environment: types.Environment{
 			"k0=v0",
@@ -120,11 +124,13 @@ func getOverrideProcess() *types.ProcessConfig {
 }
 
 func getMergedProcess() *types.ProcessConfig {
+	command := "override command"
+
 	return &types.ProcessConfig{
 		Name:        "proc1",
 		Disabled:    false,
 		IsDaemon:    false,
-		Command:     "override command",
+		Command:     &command,
 		LogLocation: "",
 		Environment: types.Environment{
 			"k0=v0",

--- a/src/tui/proc-info-form.go
+++ b/src/tui/proc-info-form.go
@@ -19,10 +19,8 @@ func (pv *pcView) createProcInfoForm(info *types.ProcessConfig, ports *types.Pro
 	f.SetFieldTextColor(tcell.ColorBlack)
 	f.SetButtonsAlign(tview.AlignCenter)
 	f.SetTitle("Process " + info.Name + " Info")
-	addStringIfNotEmpty("Entrypoint:", strings.Join(*info.Entrypoint, " "), f)
-	if info.Command != nil {
-		addStringIfNotEmpty("Command:", *info.Command, f)
-	}
+	addStringIfNotEmpty("Entrypoint:", strings.Join(info.Entrypoint, " "), f)
+	addStringIfNotEmpty("Command:", info.Command, f)
 	addStringIfNotEmpty("Working Directory:", info.WorkingDir, f)
 	addStringIfNotEmpty("Log Location:", info.LogLocation, f)
 	addDropDownIfNotEmpty("Environment:", info.Environment, f)

--- a/src/tui/proc-info-form.go
+++ b/src/tui/proc-info-form.go
@@ -19,10 +19,12 @@ func (pv *pcView) createProcInfoForm(info *types.ProcessConfig, ports *types.Pro
 	f.SetFieldTextColor(tcell.ColorBlack)
 	f.SetButtonsAlign(tview.AlignCenter)
 	f.SetTitle("Process " + info.Name + " Info")
-	addStringIfNotEmpty("Command:", info.Command, f)
+	addStringIfNotEmpty("Entrypoint:", strings.Join(*info.Entrypoint, " "), f)
+	if info.Command != nil {
+		addStringIfNotEmpty("Command:", *info.Command, f)
+	}
 	addStringIfNotEmpty("Working Directory:", info.WorkingDir, f)
 	addStringIfNotEmpty("Log Location:", info.LogLocation, f)
-	f.AddInputField("Replica:", fmt.Sprintf("%d/%d", info.ReplicaNum+1, info.Replicas), 0, nil, nil)
 	addDropDownIfNotEmpty("Environment:", info.Environment, f)
 	addCSVIfNotEmpty("Depends On:", mapKeysToSlice(info.DependsOn), f)
 	if ports != nil {

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -15,7 +15,8 @@ type ProcessConfig struct {
 	Name              string
 	Disabled          bool                   `yaml:"disabled,omitempty"`
 	IsDaemon          bool                   `yaml:"is_daemon,omitempty"`
-	Command           string                 `yaml:"command"`
+	Command           *string                `yaml:"command,omitempty"`
+	Entrypoint        *[]string              `yaml:"entrypoint,omitempty"`
 	LogLocation       string                 `yaml:"log_location,omitempty"`
 	LoggerConfig      *LoggerConfig          `yaml:"log_configuration,omitempty"`
 	Environment       Environment            `yaml:"environment,omitempty"`
@@ -31,6 +32,8 @@ type ProcessConfig struct {
 	Extensions        map[string]interface{} `yaml:",inline"`
 	ReplicaNum        int
 	ReplicaName       string
+	Executable        string
+	Args              []string
 }
 
 func (p *ProcessConfig) GetDependencies() []string {

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -15,8 +15,8 @@ type ProcessConfig struct {
 	Name              string
 	Disabled          bool                   `yaml:"disabled,omitempty"`
 	IsDaemon          bool                   `yaml:"is_daemon,omitempty"`
-	Command           *string                `yaml:"command,omitempty"`
-	Entrypoint        *[]string              `yaml:"entrypoint,omitempty"`
+	Command           string                 `yaml:"command"`
+	Entrypoint        []string               `yaml:"entrypoint"`
 	LogLocation       string                 `yaml:"log_location,omitempty"`
 	LoggerConfig      *LoggerConfig          `yaml:"log_configuration,omitempty"`
 	Environment       Environment            `yaml:"environment,omitempty"`

--- a/src/types/validators.go
+++ b/src/types/validators.go
@@ -5,6 +5,7 @@ import (
 	"github.com/f1bonacc1/process-compose/src/command"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"os"
 	"strings"
 )
 
@@ -80,10 +81,10 @@ func (p *Project) validateProcessCommand() {
 		command := proc.Command
 		entrypoint := proc.Entrypoint
 
-		if command != "" {
+		if command != "" || len(entrypoint) == 0 {
 			if len(entrypoint) > 0 {
 				message := fmt.Sprintf("Both command and entrypoint are set! Using command and ignoring entrypoint (procces: %s)", name)
-				fmt.Println(message)
+				fmt.Fprintln(os.Stderr, "process-compose:", message)
 				log.Error().Msg(message)
 			}
 
@@ -92,13 +93,9 @@ func (p *Project) validateProcessCommand() {
 				p.ShellConfig.ShellArgument,
 				command,
 			}
-		} else if len(entrypoint) > 0 {
+		} else {
 			proc.Executable = entrypoint[0]
 			proc.Args = entrypoint[1:]
-		} else {
-			message := fmt.Sprintf("Either command or entrypoint need to be non-empty (procces: %s)", name)
-			fmt.Println(message)
-			log.Fatal().Msg(message)
 		}
 
 		p.Processes[name] = proc


### PR DESCRIPTION
 ### process entrypoint

`entrypoint` is an optional array of strings which can be set on the process config
to override default shell (and shellArg) used to run the `command`

When `entrypoint` is set and is non-empty, `command` can also be omitted.

This is useful if one want's to:
1. use a different shell per process
2. run any other executable directly, without a shell wrapper

 ### `run` cmd

Equivalent of [docker-compose run](https://docs.docker.com/engine/reference/commandline/compose_run/)
which can be used to run a chosen process in the foreground (with std(in|out|err) attached),
while it's dependencies are ran in the background (no logs printed to stdio).

Deps can be disabled via --no-deps flag.

Additional arguments can be passed to the process after `--` separator, for example:

```sh
process-compose run main -- arg1 arg2
```

The separator is necessary in order to distinguish process-compose flags from flags
meant to be passed to the process.

While the process is running, the logs of the deps can be inspected using the
usual command:

```
process-compose process logs dep
```

The process being ran will have `availability.exit_on_end` set to `true` and
manually setting it to `false` will have no effect.

implements #88 and #83