### PR TITLE
imp: add nix ci gha job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,18 @@
+name: Nix
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+      - name: Nix version
+        run: nix --version
+      - name: Nix build
+        run: nix build -L .#packages.x86_64-linux.process-compose

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
   nativeBuildInputs = [ installShellFiles ];
 
   vendorHash = "sha256-0On/Rg8c9g45qbLuwhP/ZIGosu0X1uzXfAoddgTCDkg=";
-  # vendorHash = lib.fakeSha256;
+  # vendorHash = lib.fakeHash;
 
   postInstall = ''
     mv $out/bin/{src,process-compose}


### PR DESCRIPTION
* Add basic nix build gha ci to ensure the process-compose package builds before new releases are tagged.