### PR TITLE
move setInputCapture to mainGrid, except ctrl+c

### DIFF
--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -106,7 +106,9 @@ func newPcView(project app.IProject) *pcView {
 	pv.pages = tview.NewPages().
 		AddPage(PageMain, pv.mainGrid, true, true)
 
+	pv.mainGrid.SetInputCapture(pv.onMainGridKey)
 	pv.appView.SetRoot(pv.pages, true).EnableMouse(true).SetInputCapture(pv.onAppKey)
+
 	if len(pv.procNames) > 0 {
 		name := pv.procNames[0]
 		pv.logsText.SetTitle(name)
@@ -134,6 +136,15 @@ func (pv *pcView) loadShortcuts() {
 }
 
 func (pv *pcView) onAppKey(event *tcell.EventKey) *tcell.EventKey {
+	if event.Key() == tcell.KeyCtrlC {
+		pv.terminateAppView()
+		return nil
+	} else {
+		return event
+	}
+}
+
+func (pv *pcView) onMainGridKey(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Key() {
 	case pv.shortcuts.ShortCutKeys[ActionQuit].key:
 		pv.terminateAppView()
@@ -167,8 +178,6 @@ func (pv *pcView) onAppKey(event *tcell.EventKey) *tcell.EventKey {
 		pv.redrawGrid()
 		pv.onProcRowSpanChange()
 		pv.updateHelpTextView()
-	case tcell.KeyCtrlC:
-		pv.terminateAppView()
 	case pv.shortcuts.ShortCutKeys[ActionProcessScale].key:
 		pv.showScale()
 	case pv.shortcuts.ShortCutKeys[ActionProcessInfo].key:


### PR DESCRIPTION
Currently, when you open the find Dialog, pressing escape to close it does not work. First.
First, i tried checking if a `DialogPage` existed, and if it does, close it. I added this in the `ActionLogFindExit`, but this closing of the dialog page is not always connected to `Esc` is the keybinding is changed. So it needed an extra check for that. This didn't feel right to me. 

Thinking about it, it felt odd the escape never reached the PageDialog even though that page has focus. It seems that's because all the keybindings are captures in the `appView`. This always goes first, before any active page. 

So I moved this mapping to the `mainGrid` page. This caused Control+C to not be captures. So i moved just this keybinding so the appView. 

This allows the PageDialog to handle Escape before it's send to the mainGrid. Which allows the search dialog to close itself on escape. 

I tried to make sure all keybindings still work, and as far as i can tell they do. 