### PR TITLE
Feature: Filter on process list

### DIFF
--- a/src/tui/proc-filter.go
+++ b/src/tui/proc-filter.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func (pv *pcView) showProcFilter() {
+	const fieldWidth = 50
+	f := tview.NewForm()
+	f.SetCancelFunc(func() {
+		pv.pages.RemovePage(PageDialog)
+	})
+	f.SetItemPadding(1)
+	f.SetBorder(true)
+	f.SetFieldBackgroundColor(tcell.ColorLightSkyBlue)
+	f.SetFieldTextColor(tcell.ColorBlack)
+	f.SetButtonsAlign(tview.AlignCenter)
+	f.SetTitle("Search Process")
+	f.AddInputField("Search For", pv.logsText.getSearchTerm(), fieldWidth, nil, nil)
+	f.AddCheckbox("Case Sensitive", false, nil)
+	f.AddCheckbox("Regex", false, nil)
+	searchFunc := func() {
+		pv.pages.RemovePage(PageDialog)
+	}
+
+	f.AddButton("Search", searchFunc)
+	f.AddButton("Cancel", func() {
+		pv.pages.RemovePage(PageDialog)
+	})
+	f.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyEnter:
+			searchFunc()
+		case tcell.KeyEsc:
+			pv.pages.RemovePage(PageDialog)
+		default:
+			return event
+		}
+		return nil
+	})
+	f.SetFocus(0)
+	// Display and focus the dialog
+	pv.pages.AddPage(PageDialog, createDialogPage(f, fieldWidth+20, 11), true, true)
+	pv.appView.SetFocus(f)
+}

--- a/src/tui/proc-filter.go
+++ b/src/tui/proc-filter.go
@@ -33,6 +33,15 @@ func (pv *pcView) showProcFilter() {
 		searchFunc()
 	})
 
+	f.GetFormItem(0).(*tview.InputField).SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEnter {
+			pv.pages.RemovePage(PageDialog)
+			return nil
+		}
+
+		return event
+	})
+
 	f.AddButton("Search", func() {
 		pv.pages.RemovePage(PageDialog)
 	})
@@ -43,8 +52,6 @@ func (pv *pcView) showProcFilter() {
 
 	f.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
-		case tcell.KeyEnter:
-			pv.pages.RemovePage(PageDialog)
 		case tcell.KeyEsc:
 			pv.resetProcessSearch()
 			pv.pages.RemovePage(PageDialog)
@@ -54,6 +61,7 @@ func (pv *pcView) showProcFilter() {
 		return nil
 	})
 	f.SetFocus(0)
+	pv.resetProcessSearch()
 	// Display and focus the dialog
 	pv.pages.AddPage(PageDialog, createDialogPage(f, fieldWidth+20, 11), true, true)
 	pv.appView.SetFocus(f)

--- a/src/tui/proc-filter.go
+++ b/src/tui/proc-filter.go
@@ -17,22 +17,36 @@ func (pv *pcView) showProcFilter() {
 	f.SetFieldTextColor(tcell.ColorBlack)
 	f.SetButtonsAlign(tview.AlignCenter)
 	f.SetTitle("Search Process")
+
 	f.AddInputField("Search For", pv.logsText.getSearchTerm(), fieldWidth, nil, nil)
 	f.AddCheckbox("Case Sensitive", false, nil)
 	f.AddCheckbox("Regex", false, nil)
-	searchFunc := func() {
-		pv.pages.RemovePage(PageDialog)
-	}
 
-	f.AddButton("Search", searchFunc)
-	f.AddButton("Cancel", func() {
+	searchFunc := func() {
+		searchTerm := f.GetFormItem(0).(*tview.InputField).GetText()
+		caseSensitive := f.GetFormItem(1).(*tview.Checkbox).IsChecked()
+		isRegex := f.GetFormItem(2).(*tview.Checkbox).IsChecked()
+
+		pv.searchProcess(searchTerm, caseSensitive, isRegex)
+	}
+	f.GetFormItem(0).(*tview.InputField).SetChangedFunc(func(_ string) {
+		searchFunc()
+	})
+
+	f.AddButton("Search", func() {
 		pv.pages.RemovePage(PageDialog)
 	})
+	f.AddButton("Cancel", func() {
+		pv.resetProcessSearch()
+		pv.pages.RemovePage(PageDialog)
+	})
+
 	f.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
 		case tcell.KeyEnter:
-			searchFunc()
+			pv.pages.RemovePage(PageDialog)
 		case tcell.KeyEsc:
+			pv.resetProcessSearch()
 			pv.pages.RemovePage(PageDialog)
 		default:
 			return event

--- a/src/tui/proc-filter.go
+++ b/src/tui/proc-filter.go
@@ -27,7 +27,7 @@ func (pv *pcView) showProcFilter() {
 		caseSensitive := f.GetFormItem(1).(*tview.Checkbox).IsChecked()
 		isRegex := f.GetFormItem(2).(*tview.Checkbox).IsChecked()
 
-		pv.searchProcess(searchTerm, caseSensitive, isRegex)
+		pv.searchProcess(searchTerm, isRegex, caseSensitive)
 	}
 	f.GetFormItem(0).(*tview.InputField).SetChangedFunc(func(_ string) {
 		searchFunc()

--- a/src/tui/proc-filter.go
+++ b/src/tui/proc-filter.go
@@ -18,19 +18,18 @@ func (pv *pcView) showProcFilter() {
 	f.SetButtonsAlign(tview.AlignCenter)
 	f.SetTitle("Search Process")
 
-	f.AddInputField("Search For", pv.logsText.getSearchTerm(), fieldWidth, nil, nil)
+	f.AddInputField("Search For", "", fieldWidth, nil, nil)
 	f.AddCheckbox("Case Sensitive", false, nil)
 	f.AddCheckbox("Regex", false, nil)
 
-	searchFunc := func() {
-		searchTerm := f.GetFormItem(0).(*tview.InputField).GetText()
+	searchFunc := func(searchTerm string) {
 		caseSensitive := f.GetFormItem(1).(*tview.Checkbox).IsChecked()
 		isRegex := f.GetFormItem(2).(*tview.Checkbox).IsChecked()
 
 		pv.searchProcess(searchTerm, isRegex, caseSensitive)
 	}
-	f.GetFormItem(0).(*tview.InputField).SetChangedFunc(func(_ string) {
-		searchFunc()
+	f.GetFormItem(0).(*tview.InputField).SetChangedFunc(func(text string) {
+		searchFunc(text)
 	})
 
 	f.GetFormItem(0).(*tview.InputField).SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {

--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -60,6 +60,11 @@ func (pv *pcView) fillTableData() {
 		}
 		row += 1
 	}
+	if row == 1 {
+		pv.procTable.SetSelectable(false, false)
+	} else {
+		pv.procTable.SetSelectable(true, false)
+	}
 
 	// remove unnecessary rows, don't forget the title row (-1)
 	if pv.procTable.GetRowCount()-1 > row {

--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -216,7 +216,17 @@ func (pv *pcView) setTableSorter(sortBy ColumnID) {
 	}
 }
 
+func (pv *pcView) getProcessSearchRegex() *regexp.Regexp {
+	pv.processRegexMtx.Lock()
+	defer pv.processRegexMtx.Unlock()
+
+	return pv.processRegex
+}
+
 func (pv *pcView) resetProcessSearch() {
+	pv.processRegexMtx.Lock()
+	defer pv.processRegexMtx.Unlock()
+
 	pv.processRegex = nil
 	go pv.appView.QueueUpdateDraw(func() {
 		pv.fillTableData()
@@ -224,6 +234,9 @@ func (pv *pcView) resetProcessSearch() {
 }
 
 func (pv *pcView) searchProcess(search string, isRegex, caseSensitive bool) error {
+	pv.processRegexMtx.Lock()
+	defer pv.processRegexMtx.Unlock()
+
 	if search == "" {
 		pv.processRegex = nil
 		return nil

--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -207,6 +208,30 @@ func (pv *pcView) setTableSorter(sortBy ColumnID) {
 	if prevSortColumn != ProcessStateUndefined {
 		pv.procTable.GetCell(0, int(prevSortColumn)).SetText(pv.procColumns[prevSortColumn])
 	}
+}
+
+func (pv *pcView) resetProcessSearch() {
+	log.Error().Msg("Reset")
+}
+
+func (pv *pcView) searchProcess(search string, isRegex, caseSensitive bool) error {
+	if search == "" {
+		return nil
+	}
+	searchRegexString := search
+	if !isRegex {
+		searchRegexString = regexp.QuoteMeta(searchRegexString)
+	}
+	if !caseSensitive {
+		searchRegexString = "(?i)" + searchRegexString
+	}
+	searchRegex, err := regexp.Compile(searchRegexString)
+	if err != nil {
+		return err
+	}
+
+	log.Error().Msg(searchRegex.String())
+	return nil
 }
 
 func (pv *pcView) getTableSorter() StateSorter {

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -194,6 +194,10 @@ func (pv *pcView) onMainGridKey(event *tcell.EventKey) *tcell.EventKey {
 		pv.exitSearch()
 	case pv.shortcuts.ShortCutKeys[ActionNsFilter].key:
 		pv.showNsFilter()
+	case tcell.KeyRune:
+		if event.Rune() == '/' {
+			pcv.showProcFilter()
+		}
 	default:
 		return event
 	}

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"os"
 	"os/signal"
+	"regexp"
 	"strconv"
 	"sync"
 	"sync/atomic"

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -59,8 +59,8 @@ type pcView struct {
 	project           app.IProject
 	sortMtx           sync.Mutex
 	stateSorter       StateSorter
-	processRegex      *regexp.Regexp
-	processRegexMtx   sync.Mutex
+	procRegex         *regexp.Regexp
+	procRegexMtx      sync.Mutex
 	procColumns       map[ColumnID]string
 	refreshRate       time.Duration
 	cancelFn          context.CancelFunc

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -194,6 +194,7 @@ func (pv *pcView) onMainGridKey(event *tcell.EventKey) *tcell.EventKey {
 		pv.logsText.SetTitle(pv.getLogTitle(pv.getSelectedProcName()))
 	case pv.shortcuts.ShortCutKeys[ActionLogFindExit].key:
 		pv.exitSearch()
+		pv.resetProcessSearch()
 	case pv.shortcuts.ShortCutKeys[ActionNsFilter].key:
 		pv.showNsFilter()
 	case tcell.KeyRune:

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -199,7 +199,7 @@ func (pv *pcView) onMainGridKey(event *tcell.EventKey) *tcell.EventKey {
 		pv.showNsFilter()
 	case tcell.KeyRune:
 		if event.Rune() == '/' {
-			pcv.showProcFilter()
+			pv.showProcFilter()
 		} else {
 			return event
 		}

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -197,6 +197,8 @@ func (pv *pcView) onMainGridKey(event *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyRune:
 		if event.Rune() == '/' {
 			pcv.showProcFilter()
+		} else {
+			return event
 		}
 	default:
 		return event

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -60,6 +60,7 @@ type pcView struct {
 	sortMtx           sync.Mutex
 	stateSorter       StateSorter
 	processRegex      *regexp.Regexp
+	processRegexMtx   sync.Mutex
 	procColumns       map[ColumnID]string
 	refreshRate       time.Duration
 	cancelFn          context.CancelFunc

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -58,6 +58,7 @@ type pcView struct {
 	project           app.IProject
 	sortMtx           sync.Mutex
 	stateSorter       StateSorter
+	processRegex      *regexp.Regexp
 	procColumns       map[ColumnID]string
 	refreshRate       time.Duration
 	cancelFn          context.CancelFunc


### PR DESCRIPTION
Add the ability to filter on process list using `/` (vim keybinding). 
Can be confirmed with enter (has the same issue as https://github.com/F1bonacc1/process-compose/pull/135)
Or cancelled with Escape. On start it resets the search, and searches as you type to see the result. 
If cancelled early it will reset the search. 


https://github.com/F1bonacc1/process-compose/assets/126677968/83be52e7-7a94-4bd8-ab8d-5866c2f566f7

I did run into one issue where, if the search results in an empty list, it hangs the process. The processes are still running in the background (seen by the logs updating). But the TUI doesn't respond anymore, i haven't been able to figure out what the reasoning is behind this. If i click escape quickly (to cancel the search), the problem doesn't show up. 

