### PR TITLE
feat: shutdown in reverse dependency order

### DIFF
--- a/fixtures-code/process-compose-shutdown-inorder.yaml
+++ b/fixtures-code/process-compose-shutdown-inorder.yaml
@@ -1,0 +1,29 @@
+version: "0.5"
+
+log_level: debug
+log_length: 1000
+
+processes:
+  procA:
+    command: |
+      trap 'echo "A: exit"' SIGTERM
+      echo "A: starting"
+      sleep 3
+
+  procB:
+    command: |
+      trap 'echo "B: exit"' SIGTERM
+      echo "B: starting"
+      sleep 3
+    depends_on:
+      procA:
+        condition: process_started
+
+  procC:
+    command: |
+      trap 'echo "C: exit"' SIGTERM
+      echo "C: starting"
+      sleep 3
+    depends_on:
+      procB:
+        condition: process_started

--- a/src/app/project_opts.go
+++ b/src/app/project_opts.go
@@ -3,12 +3,13 @@ package app
 import "github.com/f1bonacc1/process-compose/src/types"
 
 type ProjectOpts struct {
-	project         *types.Project
-	processesToRun  []string
-	noDeps          bool
-	mainProcess     string
-	mainProcessArgs []string
-	isTuiOn         bool
+	project           *types.Project
+	processesToRun    []string
+	noDeps            bool
+	mainProcess       string
+	mainProcessArgs   []string
+	isTuiOn           bool
+	isOrderedShutDown bool
 }
 
 func (p *ProjectOpts) WithProject(project *types.Project) *ProjectOpts {
@@ -37,5 +38,10 @@ func (p *ProjectOpts) WithMainProcessArgs(mainProcessArgs []string) *ProjectOpts
 
 func (p *ProjectOpts) WithIsTuiOn(isTuiOn bool) *ProjectOpts {
 	p.isTuiOn = isTuiOn
+	return p
+}
+
+func (p *ProjectOpts) WithOrderedShutDown(isOrderedShutDown bool) *ProjectOpts {
+	p.isOrderedShutDown = isOrderedShutDown
 	return p
 }

--- a/src/cmd/project_runner.go
+++ b/src/cmd/project_runner.go
@@ -29,6 +29,7 @@ func getProjectRunner(process []string, noDeps bool, mainProcess string, mainPro
 			WithMainProcessArgs(mainProcessArgs).
 			WithProject(project).
 			WithProcessesToRun(process).
+			WithOrderedShutDown(*pcFlags.IsOrderedShutDown).
 			WithNoDeps(noDeps),
 	)
 	if err != nil {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -63,6 +63,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(pcFlags.Headless, "tui", "t", *pcFlags.Headless, "enable TUI (-t=false) (env: "+config.EnvVarNameTui+")")
 	rootCmd.PersistentFlags().BoolVar(pcFlags.KeepTuiOn, "keep-tui", *pcFlags.KeepTuiOn, "keep TUI running even after all processes exit")
 	rootCmd.PersistentFlags().BoolVar(pcFlags.NoServer, "no-server", *pcFlags.NoServer, "disable HTTP server (env: "+config.EnvVarNameNoServer+")")
+	rootCmd.PersistentFlags().BoolVar(pcFlags.IsOrderedShutDown, "ordered-shutdown", *pcFlags.IsOrderedShutDown, "shut down processes in reverse dependency order")
 	rootCmd.Flags().BoolVarP(pcFlags.HideDisabled, "hide-disabled", "d", *pcFlags.HideDisabled, "hide disabled processes")
 	rootCmd.Flags().IntVarP(pcFlags.RefreshRate, "ref-rate", "r", *pcFlags.RefreshRate, "TUI refresh rate in seconds")
 	rootCmd.PersistentFlags().IntVarP(pcFlags.PortNum, "port", "p", *pcFlags.PortNum, "port number (env: "+config.EnvVarNamePort+")")

--- a/src/config/Flags.go
+++ b/src/config/Flags.go
@@ -33,43 +33,45 @@ const (
 
 // Flags represents PC configuration flags.
 type Flags struct {
-	RefreshRate    *int
-	PortNum        *int
-	Address        *string
-	LogLevel       *string
-	LogFile        *string
-	LogLength      *int
-	LogFollow      *bool
-	LogTailLength  *int
-	Headless       *bool
-	Command        *string
-	Write          *bool
-	NoDependencies *bool
-	HideDisabled   *bool
-	SortColumn     *string
-	IsReverseSort  *bool
-	NoServer       *bool
-	KeepTuiOn      *bool
+	RefreshRate       *int
+	PortNum           *int
+	Address           *string
+	LogLevel          *string
+	LogFile           *string
+	LogLength         *int
+	LogFollow         *bool
+	LogTailLength     *int
+	Headless          *bool
+	Command           *string
+	Write             *bool
+	NoDependencies    *bool
+	HideDisabled      *bool
+	SortColumn        *string
+	IsReverseSort     *bool
+	NoServer          *bool
+	KeepTuiOn         *bool
+	IsOrderedShutDown *bool
 }
 
 // NewFlags returns new configuration flags.
 func NewFlags() *Flags {
 	return &Flags{
-		RefreshRate:    toPtr(DefaultRefreshRate),
-		Headless:       toPtr(getTuiDefault()),
-		PortNum:        toPtr(getPortDefault()),
-		Address:        toPtr(DefaultAddress),
-		LogLength:      toPtr(DefaultLogLength),
-		LogLevel:       toPtr(DefaultLogLevel),
-		LogFile:        toPtr(GetLogFilePath()),
-		LogFollow:      toPtr(false),
-		LogTailLength:  toPtr(math.MaxInt),
-		NoDependencies: toPtr(false),
-		HideDisabled:   toPtr(false),
-		SortColumn:     toPtr(DefaultSortColumn),
-		IsReverseSort:  toPtr(false),
-		NoServer:       toPtr(getNoServerDefault()),
-		KeepTuiOn:      toPtr(false),
+		RefreshRate:       toPtr(DefaultRefreshRate),
+		Headless:          toPtr(getTuiDefault()),
+		PortNum:           toPtr(getPortDefault()),
+		Address:           toPtr(DefaultAddress),
+		LogLength:         toPtr(DefaultLogLength),
+		LogLevel:          toPtr(DefaultLogLevel),
+		LogFile:           toPtr(GetLogFilePath()),
+		LogFollow:         toPtr(false),
+		LogTailLength:     toPtr(math.MaxInt),
+		NoDependencies:    toPtr(false),
+		HideDisabled:      toPtr(false),
+		SortColumn:        toPtr(DefaultSortColumn),
+		IsReverseSort:     toPtr(false),
+		NoServer:          toPtr(getNoServerDefault()),
+		KeepTuiOn:         toPtr(false),
+		IsOrderedShutDown: toPtr(false),
 	}
 }
 


### PR DESCRIPTION
processes that depend on others to start may also need to finish before them and perform some cleanup. This change makes sure that's the case.

fixes #145 

