### PR TITLE
fix: wait for processes to start when `condition: process_started`

### DIFF
--- a/src/app/project_runner.go
+++ b/src/app/project_runner.go
@@ -145,7 +145,9 @@ func (p *ProjectRunner) waitIfNeeded(process *types.ProcessConfig) error {
 				if !ready {
 					return fmt.Errorf("process %s depended on %s to become ready, but it was terminated", process.ReplicaName, k)
 				}
-
+			case types.ProcessConditionStarted:
+				log.Info().Msgf("%s is waiting for %s to start", process.ReplicaName, k)
+				runningProc.waitForStarted()
 			}
 		} else {
 			log.Error().Msgf("Error: process %s depends on %s, but it isn't running", process.ReplicaName, k)


### PR DESCRIPTION
I noticed that, in my use case (`A(depends_on: B started) -> B(depends_on: C healthy) -> C`):

- B successfully waits for C to be healthy
- A starts at the same time as C, when it should start after B

this change fixes the problematic behavior above.