### PR TITLE
Allow specifying duration for --ref-rate/-r flag

### DIFF
--- a/src/cmd/attach.go
+++ b/src/cmd/attach.go
@@ -15,7 +15,7 @@ var attachCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(attachCmd)
-	attachCmd.Flags().IntVarP(pcFlags.RefreshRate, "ref-rate", "r", *pcFlags.RefreshRate, "TUI refresh rate in seconds")
+	attachCmd.Flags().VarP(refreshRateFlag{pcFlags.RefreshRate}, "ref-rate", "r", "TUI refresh rate in seconds or as a Go duration string (e.g. 1s)")
 	attachCmd.Flags().StringVarP(pcFlags.Address, "address", "a", *pcFlags.Address, "address of the target process compose server")
 	attachCmd.Flags().IntVarP(pcFlags.LogLength, "log-length", "l", *pcFlags.LogLength, "log length to display in TUI")
 	attachCmd.Flags().AddFlag(commonFlags.Lookup(flagReverse))

--- a/src/cmd/project_runner.go
+++ b/src/cmd/project_runner.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 )
 
 func getProjectRunner(process []string, noDeps bool, mainProcess string, mainProcessArgs []string) *app.ProjectRunner {
@@ -82,7 +81,7 @@ func runTui(project *app.ProjectRunner) int {
 
 func startTui(runner app.IProject) {
 	tuiOptions := []tui.Option{
-		tui.WithRefreshRate(time.Duration(*pcFlags.RefreshRate) * time.Second),
+		tui.WithRefreshRate(*pcFlags.RefreshRate),
 	}
 	if !*pcFlags.IsReadOnlyMode {
 		config.CreateProcCompHome()

--- a/src/config/Flags.go
+++ b/src/config/Flags.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"math"
+	"time"
 )
 
 const (
 	// DefaultRefreshRate represents the refresh interval.
-	DefaultRefreshRate = 1 // secs
+	DefaultRefreshRate = 1 * time.Second
 
 	// DefaultLogLevel represents the default log level.
 	DefaultLogLevel = "info"
@@ -38,7 +39,7 @@ const (
 
 // Flags represents PC configuration flags.
 type Flags struct {
-	RefreshRate       *int
+	RefreshRate       *time.Duration
 	PortNum           *int
 	Address           *string
 	LogLevel          *string

--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -195,12 +195,14 @@ func (pv *pcView) updateTable(ctx context.Context) {
 	pv.appView.QueueUpdateDraw(func() {
 		pv.fillTableData()
 	})
+	ticker := time.NewTicker(pv.refreshRate)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			log.Debug().Msg("Table monitoring canceled")
 			return
-		case <-time.After(pv.refreshRate):
+		case <-ticker.C:
 			pv.appView.QueueUpdateDraw(func() {
 				pv.fillTableData()
 			})


### PR DESCRIPTION
This commit changes the --ref-rate/-r flag so that it accepts both an
integer in seconds (original behavior) and a custom duration string (new
behavior). This lets the user draw the UI at a higher refresh rate such
as 30fps.

It also makes a minor change in src/tui/proc-table.go, changing from
using `time.After` to `time.Ticker` to make the code slightly more
performant.
