### PR TITLE
Bump `github.com/rivo/tview` from `v0.0.0-20240307173318-e804876934a1` to `v0.0.0-20240505185119-ed116790de0f`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,8 +18,8 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  vendorHash = "sha256-X4pMes9hLMF8bZ6MX5cZdm4HfjnHYshGlA/lXlHr1Ow=";
   #vendorHash = lib.fakeHash;
+  vendorHash = "sha256-+tJVNRPmbASXOsq/ga0MN8xp0XEY/wKizVUCnY2HGPk=";
 
   postInstall = ''
     mv $out/bin/{src,process-compose}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/gorilla/websocket v1.5.1
 	github.com/joho/godotenv v1.5.1
-	github.com/rivo/tview v0.0.0-20240307173318-e804876934a1
+	github.com/rivo/tview v0.0.0-20240505185119-ed116790de0f
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/swaggo/swag v1.16.3

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/rivo/tview v0.0.0-20240307173318-e804876934a1 h1:bWLHTRekAy497pE7+nXS
 github.com/rivo/tview v0.0.0-20240307173318-e804876934a1/go.mod h1:02iFIz7K/A9jGCvrizLPvoqr4cEIx7q54RH5Qudkrss=
 github.com/rivo/tview v0.0.0-20240501114654-1f4d5e8f881d h1:NuIJVkAVUqxc34PBJx3itBUHxhcK/WJPCq7hYboc1hs=
 github.com/rivo/tview v0.0.0-20240501114654-1f4d5e8f881d/go.mod h1:02iFIz7K/A9jGCvrizLPvoqr4cEIx7q54RH5Qudkrss=
+github.com/rivo/tview v0.0.0-20240505185119-ed116790de0f h1:DAbaKhyPcZQp/TqlSdUd6Z445PkJb3bI0VccXg22oeg=
+github.com/rivo/tview v0.0.0-20240505185119-ed116790de0f/go.mod h1:02iFIz7K/A9jGCvrizLPvoqr4cEIx7q54RH5Qudkrss=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=


### PR DESCRIPTION
This version includes https://github.com/rivo/tview/issues/959, which resolves https://github.com/F1bonacc1/process-compose/issues/186.