### PR TITLE
[Fixes #197] Gracefully shutdown HTTP server

### DIFF
--- a/src/app/system_test.go
+++ b/src/app/system_test.go
@@ -146,10 +146,10 @@ func TestSystem_TestComposeChainExit(t *testing.T) {
 			t.Errorf(err.Error())
 			return
 		}
-		exitCode := runner.Run()
-		want := 42
-		if want != exitCode {
-			t.Errorf("Project.Run() = %v, want %v", exitCode, want)
+		err = runner.Run()
+		want := "project non-zero exit code: 42"
+		if want != err.Error() {
+			t.Errorf("Project.Run() = %v, want %v", err, want)
 		}
 	})
 }

--- a/src/cmd/project_runner.go
+++ b/src/cmd/project_runner.go
@@ -38,16 +38,16 @@ func getProjectRunner(process []string, noDeps bool, mainProcess string, mainPro
 	return runner
 }
 
-func runProject(runner *app.ProjectRunner) {
-	exitCode := 0
+func runProject(runner *app.ProjectRunner) error {
+	var err error
 	if *pcFlags.IsTuiEnabled {
-		exitCode = runTui(runner)
+		err = runTui(runner)
 	} else {
-		exitCode = runHeadless(runner)
+		err = runHeadless(runner)
 	}
 	os.Remove(*pcFlags.UnixSocketPath)
 	log.Info().Msg("Thank you for using process-compose")
-	os.Exit(exitCode)
+	return err
 }
 
 func setSignal(signalHandler func()) {
@@ -60,23 +60,22 @@ func setSignal(signalHandler func()) {
 	}()
 }
 
-func runHeadless(project *app.ProjectRunner) int {
+func runHeadless(project *app.ProjectRunner) error {
 	setSignal(func() {
 		_ = project.ShutDownProject()
 	})
-	exitCode := project.Run()
-	return exitCode
+	return project.Run()
 }
 
-func runTui(project *app.ProjectRunner) int {
+func runTui(project *app.ProjectRunner) error {
 	go startTui(project)
-	exitCode := project.Run()
+	err := project.Run()
 	if !*pcFlags.KeepTuiOn {
 		tui.Stop()
 	} else {
 		tui.Wait()
 	}
-	return exitCode
+	return err
 }
 
 func startTui(runner app.IProject) {

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -39,8 +39,7 @@ Command line arguments, provided after --, are passed to the PROCESS.`,
 			args,
 		)
 
-		startHttpServerIfEnabled(false, runner)
-		err := runProject(runner)
+		err := waitForProjectAndServer(!*pcFlags.IsTuiEnabled, runner)
 		handleErrorAndExit(err)
 	},
 }

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -40,7 +40,8 @@ Command line arguments, provided after --, are passed to the PROCESS.`,
 		)
 
 		startHttpServerIfEnabled(false, runner)
-		runProject(runner)
+		err := runProject(runner)
+		handleErrorAndExit(err)
 	},
 }
 

--- a/src/cmd/up.go
+++ b/src/cmd/up.go
@@ -15,7 +15,8 @@ will start them and their dependencies only`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runner := getProjectRunner(args, *pcFlags.NoDependencies, "", []string{})
 		startHttpServerIfEnabled(!*pcFlags.IsTuiEnabled, runner)
-		runProject(runner)
+		err := runProject(runner)
+		handleErrorAndExit(err)
 	},
 }
 

--- a/src/cmd/up.go
+++ b/src/cmd/up.go
@@ -14,8 +14,7 @@ If one or more process names are passed as arguments,
 will start them and their dependencies only`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runner := getProjectRunner(args, *pcFlags.NoDependencies, "", []string{})
-		startHttpServerIfEnabled(!*pcFlags.IsTuiEnabled, runner)
-		err := runProject(runner)
+		err := waitForProjectAndServer(!*pcFlags.IsTuiEnabled, runner)
 		handleErrorAndExit(err)
 	},
 }


### PR DESCRIPTION
To prevent a race condition seen in https://github.com/F1bonacc1/process-compose/issues/197:

1. On the client:
  a. User runs `process-compose down`
  b. Client makes request to `/project/stop`
2. On the server:
  a. `ProjectRunner.ShutDownProject()` stops all processes
  b. `cmd.runProject()` stops blocking
  c. Exits before `PcApi.ShutDownProject` has written the response
3. On the client:
  a. Gets `EOF` reading the response because the server has gone away

I can't think of a way to reproduce this in a test, except for something
convoluted like creating a custom client that introduces a delay in
reading the response.

It can be "manually" simulated by adding a small delay here though:

```patch
diff --git a/src/api/pc_api.go b/src/api/pc_api.go
index d123257..d069399 100644
--- a/src/api/pc_api.go
+++ b/src/api/pc_api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/f1bonacc1/process-compose/src/app"
 	"github.com/gin-gonic/gin"
@@ -268,6 +269,7 @@ func (api *PcApi) GetProcessPorts(c *gin.Context) {
 // @Router /project/stop [post]
 func (api *PcApi) ShutDownProject(c *gin.Context) {
 	api.project.ShutDownProject()
+	time.Sleep(10 * time.Millisecond)
 	c.JSON(http.StatusOK, gin.H{"status": "stopped"})
 }
```

And using this config:

```yaml
processes:
  one:
    command: sleep infinity
  two:
    command: sleep infinity
```

Before this change:

```console
bash-5.2$ go run src/main.go up --config services.yaml --tui=false &
[1] 8171
bash-5.2$ go run src/main.go down
24-07-12 15:38:40.332 FTL failed to stop project error="Post \"http://localhost:8080/project/stop\": EOF"
exit status 1
[1]+  Done                    go run src/main.go up --config services.yaml --tui=false
```

After this change:

```console
bash-5.2$ go run src/main.go up --config services.yaml --tui=false &
[1] 8432
bash-5.2$ go run src/main.go down
```