### PR TITLE
Print log write errors to stderr rather than stdout

### DIFF
--- a/src/client/logs.go
+++ b/src/client/logs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"io"
 	"net"
+    "os"
 	"sync/atomic"
 )
 
@@ -57,7 +58,7 @@ func (l *LogClient) ReadProcessLogs(name string, offset int, follow bool, out io
 func (l *LogClient) CloseChannel() error {
 	err := l.ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	if err != nil {
-		fmt.Println("write close:", err)
+		fmt.Fprintln(os.Stderr, "write close:", err)
 		return err
 	}
 	l.isClosed.Store(true)


### PR DESCRIPTION
Currently the write error message emitted by `process-compose process logs --tail` is indistinguishable from actual log output coming from the process.

```yaml
processes:
  never_exit:
    command: sleep infinity
  foo:
    command: |
      echo 1
      echo 2
      echo 3
```

will log as:

```
$ process-compose process logs -u test.sock -n 2 foo 2>/dev/null
2
3
write close: write unix ->test.sock: write: broken pipe
```

This change will make it so that `write close: write unix ->test.sock: write: broken pipe` would be printed to stderr, i.e. the same command as above would log as:

```
$ process-compose process logs -u test.sock -n 2 foo 2>/dev/null
2
3
```