### PR TITLE
fix: check if unix socket is in use

### DIFF
--- a/src/api/server.go
+++ b/src/api/server.go
@@ -16,7 +16,14 @@ func StartHttpServerWithUnixSocket(useLogger bool, unixSocket string, project ap
 	router := getRouter(useLogger, project)
 	log.Info().Msgf("start UDS http server listening %s", unixSocket)
 
+	// Check if the unix socket is already in use
+	// If it exists but we can't connect, remove it
+	_, err := net.Dial("unix", unixSocket)
+	if err == nil {
+		log.Fatal().Msgf("unix socket %s is already in use", unixSocket)
+	}
 	os.Remove(unixSocket)
+
 	server := &http.Server{
 		Handler: router.Handler(),
 	}


### PR DESCRIPTION
Currently, if two instances of process-compose are started with the same unix socket, the first instance is orphaned without any way to shut it down:

```
> process-compose up -u /tmp/sock --tui=false >/dev/null 2>&1 &
[1] 52138

> process-compose up -u /tmp/sock --tui=false >/dev/null 2>&1 &
[2] 52217

> process-compose down -u /tmp/sock
[2]  + done       process-compose up -u /tmp/sock --tui=false > /dev/null 2>&1

> process-compose down -u /tmp/sock
24-08-07 11:59:19.436 FTL failed to stop project error="Post \"http://unix/project/stop/\": dial unix /tmp/sock: connect: no such file or directory"

> pgrep process-compose
52138
```

Instead of unconditionally removing an existing unix socket, error if it is already in use.