### PR TITLE
feat: Add `availability.exit_on_skipped`

### DIFF
--- a/src/app/project_runner.go
+++ b/src/app/project_runner.go
@@ -133,6 +133,7 @@ func (p *ProjectRunner) runProcess(config *types.ProcessConfig) {
 			log.Error().Msgf("Error: %s", err.Error())
 			log.Error().Msgf("Error: process %s won't run", proc.getName())
 			proc.wontRun()
+			p.onProcessSkipped(proc.procConf)
 		} else {
 			exitCode := proc.run()
 			p.onProcessEnd(exitCode, proc.procConf)
@@ -183,6 +184,13 @@ func (p *ProjectRunner) onProcessEnd(exitCode int, procConf *types.ProcessConfig
 		procConf.RestartPolicy.ExitOnEnd {
 		p.ShutDownProject()
 		p.exitCode = exitCode
+	}
+}
+
+func (p *ProjectRunner) onProcessSkipped(procConf *types.ProcessConfig) {
+	if procConf.RestartPolicy.ExitOnSkipped {
+		p.ShutDownProject()
+		p.exitCode = 1
 	}
 }
 

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -147,6 +147,7 @@ type RestartPolicyConfig struct {
 	BackoffSeconds int    `yaml:"backoff_seconds,omitempty"`
 	MaxRestarts    int    `yaml:"max_restarts,omitempty"`
 	ExitOnEnd      bool   `yaml:"exit_on_end,omitempty"`
+	ExitOnSkipped  bool   `yaml:"exit_on_skipped,omitempty"`
 }
 
 type ShutDownParams struct {

--- a/www/docs/launcher.md
+++ b/www/docs/launcher.md
@@ -289,3 +289,28 @@ processes:
 
 > :bulb:
 > `exit_on_end` can be set on more than one process, for example when running multiple tasks in parallel and wishing to terminate as soon as any one finished.
+
+## Terminate Process Compose once given process is skipped
+
+This can be achieved by setting `availability.exit_on_skipped` to `true`. If defined, `process-compose` will gracefully shut down all the other running processes and exit with exit-code `1`.
+
+Here's an example, where `process1` depends on `process2` and `process2` fails:
+
+```yaml hl_lines="10"
+processes:
+  process1:
+    command: "echo 'Hi from Process1'"
+    depends_on:
+      process2:
+        condition: process_completed_successfully
+    availability:
+      # NOTE: `restart: exit_on_failure` is not needed since
+      # exit_on_skipped implies it.
+      exit_on_skipped: true
+  process2:
+    command: "echo 'Hi from Process2'; exit 1"
+  process3:
+    command: "while true; do echo 'Running...'; sleep 1; done"
+```
+
+Why can't the same be achieved with `exit_on_end` on `process2`? Yes, it can be, but in a case where `process1` depends on multiple processes, and failure of any of them should cause termination, `exit_on_skipped` can be used to avoid setting `exit_on_end` on all of them.


### PR DESCRIPTION
resolves #225 

Here’s a simple process-compose configuration to try this feature:

```yaml
processes:
  process1:
    command: "echo 'Hi from Process1'"
    depends_on:
      process2:
        condition: process_completed_successfully
    availability:
      exit_on_skipped: true
  process2:
    command: "echo 'Hi from Process2'; exit 1"
  process3:
    command: "while true; do echo 'Running...'; sleep 1; done"
```