### PR TITLE
fix: Prefer os.Process.Signal to syscall.Kill

### DIFF
--- a/src/command/stopper_unix.go
+++ b/src/command/stopper_unix.go
@@ -28,7 +28,7 @@ func (c *CmdWrapper) Stop(sig int, parentOnly bool) error {
 		Msg("Stop Unix process.")
 
 	if parentOnly {
-		return syscall.Kill(c.Pid(), syscall.Signal(sig))
+		return c.cmd.Process.Signal(syscall.Signal(sig))
 	}
 
 	pgid, err := syscall.Getpgid(c.Pid())


### PR DESCRIPTION
This protects us from a potential (but rare) race condition where

1. the process we are trying to signal terminates of its own accord
2. its PID gets reaped in the `os.Process.Wait` call
3. a new process with the same PID gets spawned

before our signal actually gets sent.

This is achieved by using the higher-level `os.Process` API directly, which
has some synchronization to prevent `os.Process.Wait` and `os.Process.Signal`
from racing.