### PR TITLE
Forcefully terminate all processes with a configured shutdown timeout

### DIFF
--- a/src/app/system_unix_test.go
+++ b/src/app/system_unix_test.go
@@ -1,0 +1,69 @@
+//go:build !windows
+
+package app
+
+import (
+	"github.com/f1bonacc1/process-compose/src/command"
+	"github.com/f1bonacc1/process-compose/src/types"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func assertProcessStatus(t *testing.T, runner *ProjectRunner, procName string, wantStatus string) {
+	t.Helper()
+	state, err := runner.GetProcessState(procName)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	if state.Status != wantStatus {
+		t.Fatalf("process %s status want %s got %s", procName, wantStatus, state.Status)
+	}
+}
+
+func TestSystem_TestProcShutDownWithConfiguredTimeOut(t *testing.T) {
+	ignoresSigTerm := "IgnoresSIGTERM"
+	shell := command.DefaultShellConfig()
+	timeout := 5
+
+	project := &types.Project{
+		Processes: map[string]types.ProcessConfig{
+			ignoresSigTerm: {
+				Name:        ignoresSigTerm,
+				ReplicaName: ignoresSigTerm,
+				Executable:  shell.ShellCommand,
+				Args:        []string{shell.ShellArgument, "trap '' SIGTERM && sleep 60"},
+				ShutDownParams: types.ShutDownParams{
+					ShutDownTimeout: timeout,
+					Signal:          int(syscall.SIGTERM),
+				},
+			},
+		},
+		ShellConfig: shell,
+	}
+	runner, err := NewProjectRunner(&ProjectOpts{project: project})
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	go runner.Run()
+
+	time.Sleep(100 * time.Millisecond)
+	assertProcessStatus(t, runner, ignoresSigTerm, types.ProcessStateRunning)
+
+	// If the test fails, cleanup after ourselves
+	proc := runner.getRunningProcess(ignoresSigTerm)
+	defer proc.command.Stop(int(syscall.SIGKILL), true)
+
+	err = runner.StopProcess(ignoresSigTerm)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	for i := 0; i < timeout-1; i++ {
+		time.Sleep(time.Second)
+		assertProcessStatus(t, runner, ignoresSigTerm, types.ProcessStateTerminating)
+	}
+
+	time.Sleep(2 * time.Second)
+	assertProcessStatus(t, runner, ignoresSigTerm, types.ProcessStateCompleted)
+}

--- a/src/command/command.go
+++ b/src/command/command.go
@@ -20,12 +20,6 @@ func BuildPtyCommand(cmd string, args []string) *CmdWrapperPty {
 	}
 }
 
-func BuildCommandContext(ctx context.Context, shellCmd string) *CmdWrapper {
-	return &CmdWrapper{
-		cmd: exec.CommandContext(ctx, getRunnerShell(), getRunnerArg(), shellCmd),
-	}
-}
-
 func BuildCommandShellArgContext(ctx context.Context, shell ShellConfig, cmd string) *CmdWrapper {
 	return &CmdWrapper{
 		cmd: exec.CommandContext(ctx, shell.ShellCommand, shell.ShellArgument, cmd),

--- a/src/command/command.go
+++ b/src/command/command.go
@@ -8,15 +8,15 @@ import (
 	"runtime"
 )
 
-func BuildCommand(cmd string, args []string) *CmdWrapper {
-	return &CmdWrapper{
-		cmd: exec.Command(cmd, args...),
-	}
+func BuildCommandContext(ctx context.Context, onCancel func() error, cmd string, args []string) *CmdWrapper {
+	cmdCtx := exec.CommandContext(ctx, cmd, args...)
+	cmdCtx.Cancel = onCancel
+	return &CmdWrapper{cmd: cmdCtx}
 }
 
-func BuildPtyCommand(cmd string, args []string) *CmdWrapperPty {
+func BuildPtyCommandContext(ctx context.Context, onCancel func() error, cmd string, args []string) *CmdWrapperPty {
 	return &CmdWrapperPty{
-		CmdWrapper: BuildCommand(cmd, args),
+		CmdWrapper: BuildCommandContext(ctx, onCancel, cmd, args),
 	}
 }
 

--- a/src/health/exec_checker.go
+++ b/src/health/exec_checker.go
@@ -16,7 +16,11 @@ func (c *execChecker) Status() (interface{}, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.timeout)*time.Second)
 	defer cancel()
 
-	cmd := command.BuildCommandContext(ctx, c.command)
+	cmd := command.BuildCommandShellArgContext(
+		ctx,
+		*command.DefaultShellConfig(),
+		c.command,
+	)
 	cmd.SetDir(c.workingDir)
 
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Fixes #214 

I'm not entirely convinced this change is race free, but it should be. I would appreciate if someone double checked my handling of the `p.waitDone` channel.

I assume that a modification to the docs is in order. I can take a look at that once this change is otherwise accepted.