### PR TITLE
tui: don't log.Fatal on appView.Run error

### DIFF
--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -542,7 +542,8 @@ func RunTUIAsync(project app.IProject, options ...Option) {
 	setupTui(project, options...)
 	go func() {
 		if err := pcv.appView.Run(); err != nil {
-			log.Fatal().Err(err).Msgf("Failed to start TUI")
+			log.Error().Err(err).Msgf("TUI stopped")
+			pcv.handleShutDown()
 		}
 	}()
 }
@@ -550,7 +551,8 @@ func RunTUIAsync(project app.IProject, options ...Option) {
 func RunTUI(project app.IProject, options ...Option) {
 	setupTui(project, options...)
 	if err := pcv.appView.Run(); err != nil {
-		log.Fatal().Err(err).Msgf("Failed to start TUI")
+		log.Error().Err(err).Msgf("TUI stopped")
+		pcv.handleShutDown()
 	}
 }
 


### PR DESCRIPTION
When the user closes their terminal (as opposed to ctrl-c), the terminal might close the tty without waiting for process-compose to exit. This causes `pcv.appView.Run` to return an error, which triggers a `log.Fatal`:

```
ERR Failed to start TUI error="read /dev/tty: input/output error"
```

This leads to a race where `log.Fatal` might call `os.Exit` before the project's processes can be stopped, leaving them orphaned.

Change `log.Fatal` to `log.Error` and explicitly shutdown the project to make sure processes aren't left behind.