### PR TITLE
fix #261: validate all dependencies are defined

### DIFF
--- a/src/loader/loader.go
+++ b/src/loader/loader.go
@@ -58,6 +58,7 @@ func Load(opts *LoaderOptions) (*types.Project, error) {
 		validateProcessConfig,
 		validateNoCircularDependencies,
 		validateShellConfig,
+        validateDependenciesExist,
 		validatePlatformCompatibility,
 		validateHealthDependencyHasHealthCheck,
 		validateDependencyIsEnabled,

--- a/src/loader/validators.go
+++ b/src/loader/validators.go
@@ -70,6 +70,18 @@ func validatePlatformCompatibility(p *types.Project) error {
 	return nil
 }
 
+func validateDependenciesExist(p *types.Project) error {
+	for process, config := range p.Processes {
+		for dependency := range config.DependsOn {
+			_, exists := p.Processes[dependency]
+			if !exists {
+				return fmt.Errorf("dependency process '%s' in process '%s' is not defined", dependency, process)
+			}
+		}
+	}
+	return nil
+}
+
 func validateNoCircularDependencies(p *types.Project) error {
 	visited := make(map[string]bool, len(p.Processes))
 	stack := make(map[string]bool)


### PR DESCRIPTION
Prints error and exits if undefined dependencies exist.

Fixes #261