### PR TITLE
Make nix build produce a static binary

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ buildGoModule rec {
   pname = "process-compose";
   version = "1.34.0";
 
+  CGO_ENABLED = 0;
 
   src = lib.cleanSource ./.;
   ldflags = [


### PR DESCRIPTION
Regular builds already specify CGO_ENABLED=0, making nix binaries static as well.

Fixes #265 