### PR TITLE
fix: stop loading the same project multiple times 294

### DIFF
--- a/src/loader/loader.go
+++ b/src/loader/loader.go
@@ -23,7 +23,10 @@ func Load(opts *LoaderOptions) (*types.Project, error) {
 		return nil, err
 	}
 
-	for idx, file := range opts.FileNames {
+	fileNames := make([]string, len(opts.FileNames))
+	_ = copy(fileNames, opts.FileNames)
+
+	for idx, file := range fileNames {
 		prj, err := loadProjectFromFile(file, opts)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Why
===
* https://github.com/F1bonacc1/process-compose/issues/294

What changed
===
* Make a copy of the FileNames and loop over that instead, so when loadExtendProject adds to the FileNames, it doesn't try to load it again

Test plan
===
* The repro in issue 294 now passes