### PR TITLE
feat: support namespace arg in project update command

### DIFF
--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -97,6 +97,23 @@ processes:
       success_threshold: 1
       failure_threshold: 3
 
+  process5:
+    command: "./test_loop.bash process5"
+    disable_ansi_colors: true
+    # availability:
+    #   restart: on_failure
+    environment:
+      - 'EXIT_CODE=4'
+    readiness_probe:
+      exec:
+        command: "ps -ef | grep -v grep | grep process5"
+      initial_delay_seconds: 5
+      period_seconds: 2
+      timeout_seconds: 1
+      success_threshold: 1
+      failure_threshold: 3
+    namespace: test
+
   server:
     command: "python3 -m http.server 404{{.PC_REPLICA_NUM}}"
     is_tty: true

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -86,6 +86,7 @@ func init() {
 	projectCmd.AddCommand(updateCmd)
 	updateCmd.Flags().StringArrayVarP(&opts.FileNames, "config", "f", config.GetConfigDefault(), "path to config files to load (env: "+config.EnvVarNameConfig+")")
 	updateCmd.Flags().BoolVarP(&updateVerboseOutput, "verbose", "v", updateVerboseOutput, "verbose output")
+	updateCmd.Flags().AddFlag(rootCmd.Flags().Lookup("namespace"))
 	if os.Getenv(config.EnvVarNameConfig) == "" {
 		_ = updateCmd.MarkFlagRequired("config")
 	}


### PR DESCRIPTION
**Why?**
Enable loading/unloading processes by namespace.

This allows grouping processes under namespaces, making it easier to manage dependencies in different environments. For example:
- A **dev** namespace can be used to start only development dependencies.
- The **default** namespace can be used for full integration testing.

By supporting `--namespace`, users can update projects more granularly, starting/stopping only the required processes.