### PR TITLE
Don't say "Shutting Down" when detaching

### DIFF
--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -395,8 +395,10 @@ func (pv *pcView) showInfo() {
 }
 
 func (pv *pcView) handleShutDown() {
-	pv.attentionMessage("Shutting Down...", 0)
-	if !pv.project.IsRemote() {
+	if pv.project.IsRemote() {
+		pv.attentionMessage("Detaching...", 0)
+	} else {
+		pv.attentionMessage("Shutting Down...", 0)
 		_ = pv.project.ShutDownProject()
 	}
 	time.Sleep(time.Second)


### PR DESCRIPTION
If `process-compose` is detaching from a remote project, it's not shutting down the processes, it's just detaching from _viewing_ them.

Closes #309.