### PR TITLE
Add `--detach-on-success`

### DIFF
--- a/src/app/table.go
+++ b/src/app/table.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"fmt"
+	"github.com/f1bonacc1/process-compose/src/types"
+)
+
+// Print a list of process states in a table.
+func PrintStatesAsTable(states []types.ProcessState) {
+
+	// Create a table
+	table := []string{"PID", "NAME", "NAMESPACE", "STATUS", "AGE", "HEALTH", "RESTARTS", "EXITCODE"}
+	tableColWidth := make([]int, len(table))
+
+	for _, state := range states {
+		if len(fmt.Sprintf("%d", state.Pid)) > tableColWidth[0] {
+			tableColWidth[0] = len(fmt.Sprintf("%d", state.Pid))
+		}
+		if len(state.Name) > tableColWidth[1] {
+			tableColWidth[1] = len(state.Name)
+		}
+		if len(state.Namespace) > tableColWidth[2] {
+			tableColWidth[2] = len(state.Namespace)
+		}
+		if len(state.Status) > tableColWidth[3] {
+			tableColWidth[3] = len(state.Status)
+		}
+		if len(state.SystemTime) > tableColWidth[4] {
+			tableColWidth[4] = len(state.SystemTime)
+		}
+		if len(state.Health) > tableColWidth[5] {
+			tableColWidth[5] = len(state.Health)
+		}
+		if len(fmt.Sprintf("%d", state.Restarts)) > tableColWidth[6] {
+			tableColWidth[6] = len(fmt.Sprintf("%d", state.Restarts))
+		}
+		if len(fmt.Sprintf("%d", state.ExitCode)) > tableColWidth[7] {
+			tableColWidth[7] = len(fmt.Sprintf("%d", state.ExitCode))
+		}
+	}
+	for i, col := range table {
+		if len(col) > tableColWidth[i] {
+			tableColWidth[i] = len(col)
+		}
+	}
+	for i, col := range table {
+		fmt.Printf("%-*s   ", tableColWidth[i], col)
+	}
+	fmt.Println()
+	for _, state := range states {
+		fmt.Printf("%-*d   ", tableColWidth[0], state.Pid)
+		fmt.Printf("%-*s   ", tableColWidth[1], state.Name)
+		fmt.Printf("%-*s   ", tableColWidth[2], state.Namespace)
+		fmt.Printf("%-*s   ", tableColWidth[3], state.Status)
+		fmt.Printf("%-*s   ", tableColWidth[4], state.SystemTime)
+		fmt.Printf("%-*s   ", tableColWidth[5], state.Health)
+		fmt.Printf("%-*d   ", tableColWidth[6], state.Restarts)
+		fmt.Printf("%-*d   ", tableColWidth[7], state.ExitCode)
+		fmt.Println()
+	}
+
+}

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/f1bonacc1/process-compose/src/app"
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/rs/zerolog/log"
 	"os"
@@ -40,7 +41,7 @@ func printStates(states *types.ProcessesState) {
 		}
 		os.Stdout.Write(b)
 	case "wide":
-		printStatesAsTable(states.States)
+		app.PrintStatesAsTable(states.States)
 	case "":
 		for _, state := range states.States {
 			fmt.Println(state.Name)
@@ -48,61 +49,6 @@ func printStates(states *types.ProcessesState) {
 	default:
 		log.Fatal().Msgf("unknown output format %s", *pcFlags.OutputFormat)
 	}
-}
-
-func printStatesAsTable(states []types.ProcessState) {
-
-	// Create a table
-	table := []string{"PID", "NAME", "NAMESPACE", "STATUS", "AGE", "HEALTH", "RESTARTS", "EXITCODE"}
-	tableColWidth := make([]int, len(table))
-
-	for _, state := range states {
-		if len(fmt.Sprintf("%d", state.Pid)) > tableColWidth[0] {
-			tableColWidth[0] = len(fmt.Sprintf("%d", state.Pid))
-		}
-		if len(state.Name) > tableColWidth[1] {
-			tableColWidth[1] = len(state.Name)
-		}
-		if len(state.Namespace) > tableColWidth[2] {
-			tableColWidth[2] = len(state.Namespace)
-		}
-		if len(state.Status) > tableColWidth[3] {
-			tableColWidth[3] = len(state.Status)
-		}
-		if len(state.SystemTime) > tableColWidth[4] {
-			tableColWidth[4] = len(state.SystemTime)
-		}
-		if len(state.Health) > tableColWidth[5] {
-			tableColWidth[5] = len(state.Health)
-		}
-		if len(fmt.Sprintf("%d", state.Restarts)) > tableColWidth[6] {
-			tableColWidth[6] = len(fmt.Sprintf("%d", state.Restarts))
-		}
-		if len(fmt.Sprintf("%d", state.ExitCode)) > tableColWidth[7] {
-			tableColWidth[7] = len(fmt.Sprintf("%d", state.ExitCode))
-		}
-	}
-	for i, col := range table {
-		if len(col) > tableColWidth[i] {
-			tableColWidth[i] = len(col)
-		}
-	}
-	for i, col := range table {
-		fmt.Printf("%-*s   ", tableColWidth[i], col)
-	}
-	fmt.Println()
-	for _, state := range states {
-		fmt.Printf("%-*d   ", tableColWidth[0], state.Pid)
-		fmt.Printf("%-*s   ", tableColWidth[1], state.Name)
-		fmt.Printf("%-*s   ", tableColWidth[2], state.Namespace)
-		fmt.Printf("%-*s   ", tableColWidth[3], state.Status)
-		fmt.Printf("%-*s   ", tableColWidth[4], state.SystemTime)
-		fmt.Printf("%-*s   ", tableColWidth[5], state.Health)
-		fmt.Printf("%-*d   ", tableColWidth[6], state.Restarts)
-		fmt.Printf("%-*d   ", tableColWidth[7], state.ExitCode)
-		fmt.Println()
-	}
-
 }
 
 func init() {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -100,6 +100,7 @@ func init() {
 	if runtime.GOOS != "windows" {
 		rootCmd.Flags().BoolVarP(pcFlags.IsDetached, "detached", "D", *pcFlags.IsDetached, "run process-compose in detached mode")
 		rootCmd.Flags().BoolVar(pcFlags.IsDetachedWithTui, "detached-with-tui", *pcFlags.IsDetachedWithTui, "run process-compose in detached mode with TUI")
+		rootCmd.Flags().BoolVar(pcFlags.DetachOnSuccess, "detach-on-success", *pcFlags.DetachOnSuccess, "detach the process-compose TUI after successful startup. Requires --detached-with-tui")
 		rootCmd.PersistentFlags().StringVarP(pcFlags.UnixSocketPath, "unix-socket", "u", config.GetUnixSocketPath(), "path to unix socket (env: "+config.EnvVarUnixSocketPath+")")
 		rootCmd.PersistentFlags().BoolVarP(pcFlags.IsUnixSocket, "use-uds", "U", *pcFlags.IsUnixSocket, "use unix domain sockets instead of tcp")
 	}

--- a/src/config/Flags.go
+++ b/src/config/Flags.go
@@ -73,6 +73,7 @@ type Flags struct {
 	IsTuiFullScreen   *bool
 	IsDetached        *bool
 	IsDetachedWithTui *bool
+	DetachOnSuccess   *bool
 }
 
 // NewFlags returns new configuration flags.
@@ -105,6 +106,7 @@ func NewFlags() *Flags {
 		IsDetached:        toPtr(false),
 		IsDetachedWithTui: toPtr(false),
 		IsRawLogOutput:    toPtr(false),
+		DetachOnSuccess:   toPtr(false),
 	}
 }
 

--- a/src/tui/tui_option.go
+++ b/src/tui/tui_option.go
@@ -52,3 +52,10 @@ func WithDisabledExitConfirm(isDisabled bool) Option {
 		return nil
 	}
 }
+
+func WithDetachOnSuccess(detachOnSuccess bool) Option {
+	return func(view *pcView) error {
+		view.detachOnSuccess = detachOnSuccess
+		return nil
+	}
+}

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -88,6 +88,7 @@ type pcView struct {
 	isFullScreen          bool
 	isReadOnlyMode        bool
 	isExitConfirmDisabled bool
+	detachOnSuccess       bool
 }
 
 func newPcView(project app.IProject) *pcView {


### PR DESCRIPTION
`process-compose --detached-with-tui --detach-on-success` will act like `--detached-with-tui`, but will automatically detach if and when all processes start up succesfully.

After detaching, a table showing the started processes is printed automatically.

Closes #311