### PR TITLE
fix: wrong serialization on process state `IsRunning`

### DIFF
--- a/src/types/process.go
+++ b/src/types/process.go
@@ -218,7 +218,7 @@ type ProcessState struct {
 	PasswordProvided bool          `json:"password_provided"`
 	Mem              int64         `json:"mem"`
 	CPU              float64       `json:"cpu"`
-	IsRunning        bool
+	IsRunning        bool          `json:"is_running"`
 }
 
 type ProcessPorts struct {


### PR DESCRIPTION
- Fix `IsRunning` (should be `is_running`) serialization on the process state, to be aligned with the other outputs.