### PR TITLE
Shutdown instantly

### DIFF
--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -401,7 +401,6 @@ func (pv *pcView) handleShutDown() {
 		pv.attentionMessage("Shutting Down...", 0)
 		_ = pv.project.ShutDownProject()
 	}
-	time.Sleep(time.Second)
 	pv.stopFollowLog()
 	pv.appView.Stop()
 	pv.cancelAppFn()


### PR DESCRIPTION
Previously, attempting to shut down `process-compose` would incur a 1-second delay.

With #312, this meant that `process-compose --detached-with-tui --detach-on-success` would take longer than 1 second to return, even if the project was already running and healthy (and therefore the command should have been a no-op).

Removing this sleep makes that command take ~90ms instead of ~1050ms.