### PR TITLE
Don't log "flushing"

### DIFF
--- a/src/pclog/logger_facade.go
+++ b/src/pclog/logger_facade.go
@@ -180,7 +180,6 @@ func (l *PCLog) runCollector() {
 		}
 		level.Msg(event.message)
 		if l.flushEachLine {
-			log.Debug().Msg("flushing")
 			l.writer.Flush()
 		}
 	}


### PR DESCRIPTION
These messages are not very useful and they clog up the logs:

    $ cat .pc/logs/process-compose.log | rg flushing | wc -l
    8940