### PR TITLE
GitHub Actions: Fix docs build in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,5 +28,13 @@ jobs:
           path: .cache
       - run: pip install mkdocs-material
       - run: pip install pillow cairosvg
-      - run: mkdocs gh-deploy --force
+
+      - name: Build docs
+        if: ${{ github.event_name == 'pull_request' }}
+        run: mkdocs build
+        working-directory: ./www
+
+      - name: Deploy docs to GitHub Pages
+        if: ${{ github.event_name != 'pull_request' }}
+        run: mkdocs gh-deploy --force
         working-directory: ./www

--- a/www/mkdocs.yml
+++ b/www/mkdocs.yml
@@ -92,8 +92,8 @@ markdown_extensions:
   - pymdownx.mark
   - attr_list
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 copyright: |
   &copy; 2024 <a href="https://github.com/f1bonacc1"  target="_blank" rel="noopener">Eugene Berger</a>


### PR DESCRIPTION
I noticed that the docs CI build for #326 failed with a permissions error:

```
INFO    -  Copying '/home/runner/work/process-compose/process-compose/www/site' to 'gh-pages' branch and pushing to GitHub.
remote: Permission to F1bonacc1/process-compose.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/F1bonacc1/process-compose/': The requested URL returned error: 403
```

We don't want to deploy the docs for PR CI runs, so let's run `mkdocs build` instead to make sure the docs build without deploying them.

I also updated the `mkdocs.yml` to fix this deprecation warning:


    Material emoji logic has been officially moved into mkdocs-material
    version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
    instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

    ```
    markdown_extensions:
      - pymdownx.emoji:
          emoji_index: !!python/name:material.extensions.emoji.twemoji
          emoji_generator: !!python/name:material.extensions.emoji.to_svg
    ```

    'mkdocs_material_extensions' is deprecated and will no longer be
    supported moving forward. This is the last release.

