### PR TITLE
table: color rows according to proc status

### DIFF
--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -403,9 +403,9 @@ func (pv *pcView) getIconForState(state types.ProcessState) (string, tcell.Color
 		if state.ExitCode == 0 {
 			return "●", pv.styles.ProcTable().FgCompleted.Color()
 		}
-		return "❌", pv.styles.ProcTable().FgError.Color()
+		return "✘", pv.styles.ProcTable().FgError.Color()
 	case types.ProcessStateError:
-		return "❌", pv.styles.ProcTable().FgError.Color()
+		return "✘", pv.styles.ProcTable().FgError.Color()
 	case types.ProcessStateDisabled,
 		types.ProcessStateForeground:
 		return "◯", pv.styles.ProcTable().FgPending.Color()

--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -403,9 +403,9 @@ func (pv *pcView) getIconForState(state types.ProcessState) (string, tcell.Color
 		if state.ExitCode == 0 {
 			return "●", pv.styles.ProcTable().FgCompleted.Color()
 		}
-		return "●", pv.styles.ProcTable().FgError.Color()
+		return "❌", pv.styles.ProcTable().FgError.Color()
 	case types.ProcessStateError:
-		return "●", pv.styles.ProcTable().FgError.Color()
+		return "❌", pv.styles.ProcTable().FgError.Color()
 	case types.ProcessStateDisabled,
 		types.ProcessStateForeground:
 		return "◯", pv.styles.ProcTable().FgPending.Color()
@@ -481,7 +481,7 @@ func (pv *pcView) getTableRowValues(state types.ProcessState) tableRowValues {
 	return tableRowValues{
 		icon:      icon,
 		iconColor: color,
-		fgColor:   pv.styles.ProcTable().FgColor.Color(),
+		fgColor:   color,
 		pid:       strconv.Itoa(state.Pid),
 		name:      state.Name,
 		ns:        state.Namespace,


### PR DESCRIPTION
At work, we use `--detach-on-success` (https://github.com/F1bonacc1/process-compose/pull/312) to automatically exit the `process-compose` TUI when processes finish starting up. When processes fail to start up, engineers often don't notice that a process has failed, and instead assume that `process-compose` has a bug.

The UI makes it pretty easy to miss a failed process; the icon on the left of the table is red, but that's about it. The exit code is off to the right, and it's not immediately obvious that a 1 means there's a problem.

We can make the UI significantly more legible by coloring rows according to the process state. We'll reuse the color of the state icon for this. This displays nicely when rows are selected as well; a selected failed process will show up with black text on a red background, making the failure very clear (as opposed to the previous default blue background).

### Before

<img width="955" alt="image" src="https://github.com/user-attachments/assets/be4f48a6-f472-401e-a479-282a61ddc433" />

### After

<img width="951" alt="image" src="https://github.com/user-attachments/assets/9736d70f-d72c-4f08-acef-435c102569d9" />
