### PR TITLE
table: display "Failed" for status

### DIFF
--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -485,7 +485,7 @@ func (pv *pcView) getTableRowValues(state types.ProcessState) tableRowValues {
 		pid:       strconv.Itoa(state.Pid),
 		name:      state.Name,
 		ns:        state.Namespace,
-		status:    state.Status,
+		status:    types.DisplayProcessStatus(state),
 		age:       state.SystemTime,
 		health:    state.Health,
 		mem:       getStrForMem(state.Mem, state.IsRunning),

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -331,6 +331,21 @@ const (
 	ProcessStateError       = "Error"
 )
 
+// Display a process status for the UI.
+//
+// In particular, this displays "Failed" if the process has completed with a
+// non-zero exit code. This makes it clearer when a process has failed, as
+// opposed to exiting successfully.
+//
+// We can't change the `Status` field to "Failed" directly because that would
+// change the JSON API behavior, but we can change it in the TUI.
+func DisplayProcessStatus(state ProcessState) string {
+	if state.Status == ProcessStateCompleted && state.ExitCode != 0 {
+		return "Failed"
+	}
+	return state.Status
+}
+
 const (
 	ProcessHealthReady    = "Ready"
 	ProcessHealthNotReady = "Not Ready"


### PR DESCRIPTION
Related: #339

When a process completes with a non-zero exit code, display "Failed" in the "Status" column instead of "Completed". "Completed" sounds like everything is OK, and "Failed" makes it clearer that something has gone wrong.

### Before

<img width="955" alt="image" src="https://github.com/user-attachments/assets/be4f48a6-f472-401e-a479-282a61ddc433" />


### After

<img width="955" alt="image" src="https://github.com/user-attachments/assets/c41f5170-1579-4625-be9e-1042503d0d5f" />
