### PR TITLE
feat: default to imprecise metrics and provide option to enable them

### DIFF
--- a/src/app/proc_opts.go
+++ b/src/app/proc_opts.go
@@ -86,3 +86,9 @@ func withRefRate(refRate time.Duration) ProcOpts {
 		proc.refRate = refRate
 	}
 }
+
+func withRecursiveMetrics(withRecursiveMetrics bool) ProcOpts {
+	return func(proc *Process) {
+		proc.withRecursiveMetrics = withRecursiveMetrics
+	}
+}

--- a/src/app/process.go
+++ b/src/app/process.go
@@ -36,52 +36,53 @@ const (
 
 type Process struct {
 	sync.Mutex
-	globalEnv           []string
-	confMtx             sync.Mutex
-	procConf            *types.ProcessConfig
-	procState           *types.ProcessState
-	stateMtx            sync.Mutex
-	procCond            sync.Cond
-	procStartedChan     chan struct{}
-	procStateChan       chan string
-	procReadyCtx        context.Context
-	readyCancelFn       context.CancelFunc
-	procLogReadyCtx     context.Context
-	readyLogCancelFn    context.CancelCauseFunc
-	procRunCtx          context.Context
-	runCancelFn         context.CancelFunc
-	waitForPassCtx      context.Context
-	waitForPassCancelFn context.CancelFunc
-	mtxStopFn           sync.Mutex
-	waitForStoppedCtx   context.Context
-	waitForStoppedFn    context.CancelFunc
-	procColor           func(a ...interface{}) string
-	noColor             func(a ...interface{}) string
-	redColor            func(a ...interface{}) string
-	logBuffer           *pclog.ProcessLogBuffer
-	logger              pclog.PcLogger
-	command             command.Commander
-	started             bool
-	done                bool
-	timeMutex           sync.Mutex
-	startTime           time.Time
-	liveProber          *health.Prober
-	readyProber         *health.Prober
-	shellConfig         command.ShellConfig
-	printLogs           bool
-	isMain              bool
-	extraArgs           []string
-	isStopped           atomic.Bool
-	stdin               io.WriteCloser
-	passProvided        bool
-	isTuiEnabled        bool
-	stdOutDone          chan struct{}
-	stdErrDone          chan struct{}
-	dotEnvVars          map[string]string
-	truncateLogs        bool
-	metricsProc         *puproc.Process
-	lastStatusPoll      time.Time
-	refRate             time.Duration
+	globalEnv            []string
+	confMtx              sync.Mutex
+	procConf             *types.ProcessConfig
+	procState            *types.ProcessState
+	stateMtx             sync.Mutex
+	procCond             sync.Cond
+	procStartedChan      chan struct{}
+	procStateChan        chan string
+	procReadyCtx         context.Context
+	readyCancelFn        context.CancelFunc
+	procLogReadyCtx      context.Context
+	readyLogCancelFn     context.CancelCauseFunc
+	procRunCtx           context.Context
+	runCancelFn          context.CancelFunc
+	waitForPassCtx       context.Context
+	waitForPassCancelFn  context.CancelFunc
+	mtxStopFn            sync.Mutex
+	waitForStoppedCtx    context.Context
+	waitForStoppedFn     context.CancelFunc
+	procColor            func(a ...interface{}) string
+	noColor              func(a ...interface{}) string
+	redColor             func(a ...interface{}) string
+	logBuffer            *pclog.ProcessLogBuffer
+	logger               pclog.PcLogger
+	command              command.Commander
+	started              bool
+	done                 bool
+	timeMutex            sync.Mutex
+	startTime            time.Time
+	liveProber           *health.Prober
+	readyProber          *health.Prober
+	shellConfig          command.ShellConfig
+	printLogs            bool
+	isMain               bool
+	extraArgs            []string
+	isStopped            atomic.Bool
+	stdin                io.WriteCloser
+	passProvided         bool
+	isTuiEnabled         bool
+	stdOutDone           chan struct{}
+	stdErrDone           chan struct{}
+	dotEnvVars           map[string]string
+	truncateLogs         bool
+	metricsProc          *puproc.Process
+	lastStatusPoll       time.Time
+	refRate              time.Duration
+	withRecursiveMetrics bool
 }
 
 func NewProcess(opts ...ProcOpts) *Process {
@@ -580,9 +581,11 @@ func (p *Process) getResourceUsage() (int64, float64) {
 	if p.metricsProc == nil {
 		return -1, -1
 	}
-	totalMem, totalCpu := p.getProcResourcesRecursive(p.metricsProc)
+	if p.withRecursiveMetrics {
+		return p.getProcResourcesRecursive(p.metricsProc)
+	}
 
-	return totalMem, totalCpu
+	return p.getProcResources(p.metricsProc)
 }
 
 // recursively get the memory and cpu usage of the process and its children

--- a/src/app/project_opts.go
+++ b/src/app/project_opts.go
@@ -6,16 +6,17 @@ import (
 )
 
 type ProjectOpts struct {
-	project           *types.Project
-	processesToRun    []string
-	noDeps            bool
-	mainProcess       string
-	mainProcessArgs   []string
-	isTuiOn           bool
-	isOrderedShutDown bool
-	disableDotenv     bool
-	truncateLogs      bool
-	refRate           time.Duration
+	project              *types.Project
+	processesToRun       []string
+	noDeps               bool
+	mainProcess          string
+	mainProcessArgs      []string
+	isTuiOn              bool
+	isOrderedShutDown    bool
+	disableDotenv        bool
+	truncateLogs         bool
+	refRate              time.Duration
+	withRecursiveMetrics bool
 }
 
 func (p *ProjectOpts) WithProject(project *types.Project) *ProjectOpts {
@@ -64,5 +65,10 @@ func (p *ProjectOpts) WithLogTruncate(truncateLogs bool) *ProjectOpts {
 
 func (p *ProjectOpts) WithSlowRefRate(refRate time.Duration) *ProjectOpts {
 	p.refRate = refRate
+	return p
+}
+
+func (p *ProjectOpts) WithRecursiveMetrics(withRecursiveMetrics bool) *ProjectOpts {
+	p.withRecursiveMetrics = withRecursiveMetrics
 	return p
 }

--- a/src/app/project_runner.go
+++ b/src/app/project_runner.go
@@ -32,29 +32,30 @@ func (e *ExitError) Error() string {
 }
 
 type ProjectRunner struct {
-	procConfMutex     sync.Mutex
-	project           *types.Project
-	logsMutex         sync.Mutex
-	processLogs       map[string]*pclog.ProcessLogBuffer
-	statesMutex       sync.Mutex
-	processStates     map[string]*types.ProcessState
-	runProcMutex      sync.Mutex
-	runningProcesses  map[string]*Process
-	doneProcMutex     sync.Mutex
-	doneProcesses     map[string]*Process
-	logger            pclog.PcLogger
-	waitGroup         sync.WaitGroup
-	exitCode          int
-	projectState      *types.ProjectState
-	mainProcess       string
-	mainProcessArgs   []string
-	isTuiOn           bool
-	isOrderedShutDown bool
-	ctxApp            context.Context
-	cancelAppFn       context.CancelFunc
-	disableDotenv     bool
-	truncateLogs      bool
-	refRate           time.Duration
+	procConfMutex        sync.Mutex
+	project              *types.Project
+	logsMutex            sync.Mutex
+	processLogs          map[string]*pclog.ProcessLogBuffer
+	statesMutex          sync.Mutex
+	processStates        map[string]*types.ProcessState
+	runProcMutex         sync.Mutex
+	runningProcesses     map[string]*Process
+	doneProcMutex        sync.Mutex
+	doneProcesses        map[string]*Process
+	logger               pclog.PcLogger
+	waitGroup            sync.WaitGroup
+	exitCode             int
+	projectState         *types.ProjectState
+	mainProcess          string
+	mainProcessArgs      []string
+	isTuiOn              bool
+	isOrderedShutDown    bool
+	ctxApp               context.Context
+	cancelAppFn          context.CancelFunc
+	disableDotenv        bool
+	truncateLogs         bool
+	refRate              time.Duration
+	withRecursiveMetrics bool
 }
 
 func (p *ProjectRunner) GetLexicographicProcessNames() ([]string, error) {
@@ -143,6 +144,7 @@ func (p *ProjectRunner) runProcess(config *types.ProcessConfig) {
 		withExtraArgs(extraArgs),
 		withLogsTruncate(p.truncateLogs),
 		withRefRate(p.refRate),
+		withRecursiveMetrics(p.withRecursiveMetrics),
 	)
 	p.addRunningProcess(process)
 	p.waitGroup.Add(1)
@@ -920,14 +922,15 @@ func NewProjectRunner(opts *ProjectOpts) (*ProjectRunner, error) {
 		username = current.Username
 	}
 	runner := &ProjectRunner{
-		project:           opts.project,
-		mainProcess:       opts.mainProcess,
-		mainProcessArgs:   opts.mainProcessArgs,
-		isTuiOn:           opts.isTuiOn,
-		isOrderedShutDown: opts.isOrderedShutDown,
-		disableDotenv:     opts.disableDotenv,
-		truncateLogs:      opts.truncateLogs,
-		refRate:           opts.refRate,
+		project:              opts.project,
+		mainProcess:          opts.mainProcess,
+		mainProcessArgs:      opts.mainProcessArgs,
+		isTuiOn:              opts.isTuiOn,
+		isOrderedShutDown:    opts.isOrderedShutDown,
+		disableDotenv:        opts.disableDotenv,
+		truncateLogs:         opts.truncateLogs,
+		refRate:              opts.refRate,
+		withRecursiveMetrics: opts.withRecursiveMetrics,
 		projectState: &types.ProjectState{
 			FileNames: opts.project.FileNames,
 			StartTime: time.Now(),

--- a/src/cmd/project_runner.go
+++ b/src/cmd/project_runner.go
@@ -33,7 +33,8 @@ func getProjectRunner(process []string, noDeps bool, mainProcess string, mainPro
 			WithOrderedShutDown(*pcFlags.IsOrderedShutDown).
 			WithNoDeps(noDeps).
 			WithLogTruncate(*pcFlags.LogsTruncate).
-			WithSlowRefRate(*pcFlags.SlowRefreshRate),
+			WithSlowRefRate(*pcFlags.SlowRefreshRate).
+			WithRecursiveMetrics(*pcFlags.WithRecursiveMetrics),
 	)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize the project")

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -100,6 +100,7 @@ func init() {
 	rootCmd.Flags().BoolVar(pcFlags.DisableDotEnv, "disable-dotenv", *pcFlags.DisableDotEnv, "disable .env file loading (env: "+config.EnvVarDisableDotEnv+"=1)")
 	rootCmd.Flags().BoolVar(pcFlags.IsTuiFullScreen, "tui-fs", *pcFlags.IsTuiFullScreen, "enable TUI full screen (env: "+config.EnvVarTuiFullScreen+"=1)")
 	rootCmd.Flags().BoolVar(pcFlags.LogsTruncate, "logs-truncate", *pcFlags.LogsTruncate, "truncate process logs buffer on startup")
+	rootCmd.Flags().BoolVar(pcFlags.WithRecursiveMetrics, "recursive-metrics", *pcFlags.WithRecursiveMetrics, "collect metrics recursively (env: "+config.EnvVarWithRecursiveMetrics+")")
 	rootCmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "validate the config and exit")
 	rootCmd.Flags().AddFlag(commonFlags.Lookup(flagReverse))
 	rootCmd.Flags().AddFlag(commonFlags.Lookup(flagSort))

--- a/src/cmd/up.go
+++ b/src/cmd/up.go
@@ -38,6 +38,7 @@ func init() {
 	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("shortcuts"))
 	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("logs-truncate"))
 	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("dry-run"))
+	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("recursive-metrics"))
 	upCmd.Flags().AddFlag(commonFlags.Lookup(flagReverse))
 	upCmd.Flags().AddFlag(commonFlags.Lookup(flagSort))
 	upCmd.Flags().AddFlag(commonFlags.Lookup(flagTheme))

--- a/src/config/Flags.go
+++ b/src/config/Flags.go
@@ -32,97 +32,100 @@ const (
 )
 
 const (
-	EnvVarNamePort       = "PC_PORT_NUM"
-	EnvVarNameTui        = "PC_DISABLE_TUI"
-	EnvVarNameConfig     = "PC_CONFIG_FILES"
-	EnvVarNameShortcuts  = "PC_SHORTCUTS_FILES"
-	EnvVarNameNoServer   = "PC_NO_SERVER"
-	EnvVarUnixSocketPath = "PC_SOCKET_PATH"
-	EnvVarReadOnlyMode   = "PC_READ_ONLY"
-	EnvVarDisableDotEnv  = "PC_DISABLE_DOTENV"
-	EnvVarTuiFullScreen  = "PC_TUI_FULL_SCREEN"
-	EnvVarHideDisabled   = "PC_HIDE_DISABLED_PROC"
+	EnvVarNamePort             = "PC_PORT_NUM"
+	EnvVarNameTui              = "PC_DISABLE_TUI"
+	EnvVarNameConfig           = "PC_CONFIG_FILES"
+	EnvVarNameShortcuts        = "PC_SHORTCUTS_FILES"
+	EnvVarNameNoServer         = "PC_NO_SERVER"
+	EnvVarUnixSocketPath       = "PC_SOCKET_PATH"
+	EnvVarReadOnlyMode         = "PC_READ_ONLY"
+	EnvVarDisableDotEnv        = "PC_DISABLE_DOTENV"
+	EnvVarTuiFullScreen        = "PC_TUI_FULL_SCREEN"
+	EnvVarHideDisabled         = "PC_HIDE_DISABLED_PROC"
+	EnvVarWithRecursiveMetrics = "PC_RECURSIVE_METRICS"
 )
 
 // Flags represents PC configuration flags.
 type Flags struct {
-	RefreshRate       *time.Duration
-	SlowRefreshRate   *time.Duration
-	PortNum           *int
-	Address           *string
-	LogLevel          *string
-	LogFile           *string
-	LogLength         *int
-	LogFollow         *bool
-	LogTailLength     *int
-	IsRawLogOutput    *bool
-	IsTuiEnabled      *bool
-	Command           *string
-	Write             *bool
-	NoDependencies    *bool
-	HideDisabled      *bool
-	SortColumn        *string
-	SortColumnChanged bool
-	IsReverseSort     *bool
-	NoServer          *bool
-	KeepTuiOn         *bool
-	KeepProjectOn     *bool
-	IsOrderedShutDown *bool
-	PcTheme           *string
-	PcThemeChanged    bool
-	ShortcutPaths     *[]string
-	UnixSocketPath    *string
-	IsUnixSocket      *bool
-	IsReadOnlyMode    *bool
-	OutputFormat      *string
-	DisableDotEnv     *bool
-	IsTuiFullScreen   *bool
-	IsDetached        *bool
-	IsDetachedWithTui *bool
-	Namespace         *string
-	DetachOnSuccess   *bool
-	WaitReady         *bool
-	ShortVersion      *bool
-	LogsTruncate      *bool
+	RefreshRate          *time.Duration
+	SlowRefreshRate      *time.Duration
+	PortNum              *int
+	Address              *string
+	LogLevel             *string
+	LogFile              *string
+	LogLength            *int
+	LogFollow            *bool
+	LogTailLength        *int
+	IsRawLogOutput       *bool
+	IsTuiEnabled         *bool
+	Command              *string
+	Write                *bool
+	NoDependencies       *bool
+	HideDisabled         *bool
+	SortColumn           *string
+	SortColumnChanged    bool
+	IsReverseSort        *bool
+	NoServer             *bool
+	KeepTuiOn            *bool
+	KeepProjectOn        *bool
+	IsOrderedShutDown    *bool
+	PcTheme              *string
+	PcThemeChanged       bool
+	ShortcutPaths        *[]string
+	UnixSocketPath       *string
+	IsUnixSocket         *bool
+	IsReadOnlyMode       *bool
+	OutputFormat         *string
+	DisableDotEnv        *bool
+	IsTuiFullScreen      *bool
+	IsDetached           *bool
+	IsDetachedWithTui    *bool
+	Namespace            *string
+	DetachOnSuccess      *bool
+	WaitReady            *bool
+	ShortVersion         *bool
+	LogsTruncate         *bool
+	WithRecursiveMetrics *bool
 }
 
 // NewFlags returns new configuration flags.
 func NewFlags() *Flags {
 	return &Flags{
-		RefreshRate:       toPtr(DefaultRefreshRate),
-		SlowRefreshRate:   toPtr(DefaultRefreshRate),
-		IsTuiEnabled:      toPtr(getDisableTuiDefault()),
-		PortNum:           toPtr(getPortDefault()),
-		Address:           toPtr(DefaultAddress),
-		LogLength:         toPtr(DefaultLogLength),
-		LogLevel:          toPtr(DefaultLogLevel),
-		LogFile:           toPtr(GetLogFilePath()),
-		LogFollow:         toPtr(false),
-		LogTailLength:     toPtr(math.MaxInt),
-		NoDependencies:    toPtr(false),
-		HideDisabled:      toPtr(getHideDisabledDefault()),
-		SortColumn:        toPtr(DefaultSortColumn),
-		IsReverseSort:     toPtr(false),
-		NoServer:          toPtr(getNoServerDefault()),
-		KeepTuiOn:         toPtr(false),
-		KeepProjectOn:     toPtr(false),
-		IsOrderedShutDown: toPtr(false),
-		PcTheme:           toPtr(DefaultThemeName),
-		ShortcutPaths:     toPtr(GetShortCutsPaths(nil)),
-		UnixSocketPath:    toPtr(""),
-		IsUnixSocket:      toPtr(false),
-		IsReadOnlyMode:    toPtr(getReadOnlyDefault()),
-		OutputFormat:      toPtr(""),
-		DisableDotEnv:     toPtr(getDisableDotEnvDefault()),
-		IsTuiFullScreen:   toPtr(getTuiFullScreenDefault()),
-		IsDetached:        toPtr(false),
-		IsDetachedWithTui: toPtr(false),
-		IsRawLogOutput:    toPtr(false),
-		Namespace:         toPtr(NoNamespace),
-		DetachOnSuccess:   toPtr(false),
-		WaitReady:         toPtr(false),
-		ShortVersion:      toPtr(false),
-		LogsTruncate:      toPtr(false),
+		RefreshRate:          toPtr(DefaultRefreshRate),
+		SlowRefreshRate:      toPtr(DefaultRefreshRate),
+		IsTuiEnabled:         toPtr(getDisableTuiDefault()),
+		PortNum:              toPtr(getPortDefault()),
+		Address:              toPtr(DefaultAddress),
+		LogLength:            toPtr(DefaultLogLength),
+		LogLevel:             toPtr(DefaultLogLevel),
+		LogFile:              toPtr(GetLogFilePath()),
+		LogFollow:            toPtr(false),
+		LogTailLength:        toPtr(math.MaxInt),
+		NoDependencies:       toPtr(false),
+		HideDisabled:         toPtr(getHideDisabledDefault()),
+		SortColumn:           toPtr(DefaultSortColumn),
+		IsReverseSort:        toPtr(false),
+		NoServer:             toPtr(getNoServerDefault()),
+		KeepTuiOn:            toPtr(false),
+		KeepProjectOn:        toPtr(false),
+		IsOrderedShutDown:    toPtr(false),
+		PcTheme:              toPtr(DefaultThemeName),
+		ShortcutPaths:        toPtr(GetShortCutsPaths(nil)),
+		UnixSocketPath:       toPtr(""),
+		IsUnixSocket:         toPtr(false),
+		IsReadOnlyMode:       toPtr(getReadOnlyDefault()),
+		OutputFormat:         toPtr(""),
+		DisableDotEnv:        toPtr(getDisableDotEnvDefault()),
+		IsTuiFullScreen:      toPtr(getTuiFullScreenDefault()),
+		IsDetached:           toPtr(false),
+		IsDetachedWithTui:    toPtr(false),
+		IsRawLogOutput:       toPtr(false),
+		Namespace:            toPtr(NoNamespace),
+		DetachOnSuccess:      toPtr(false),
+		WaitReady:            toPtr(false),
+		ShortVersion:         toPtr(false),
+		LogsTruncate:         toPtr(false),
+		WithRecursiveMetrics: toPtr(getWithRecursiveMetricsEnvDefault()),
 	}
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -238,3 +238,8 @@ func getHideDisabledDefault() bool {
 	_, found := os.LookupEnv(EnvVarHideDisabled)
 	return found
 }
+
+func getWithRecursiveMetricsEnvDefault() bool {
+	_, found := os.LookupEnv(EnvVarWithRecursiveMetrics)
+	return found
+}

--- a/www/docs/cli/process-compose.md
+++ b/www/docs/cli/process-compose.md
@@ -25,6 +25,7 @@ process-compose [flags]
       --ordered-shutdown         shut down processes in reverse dependency order
   -p, --port int                 port number (env: PC_PORT_NUM) (default 8080)
       --read-only                enable read-only mode (env: PC_READ_ONLY)
+      --recursive-metrics        collect metrics recursively (env: PC_RECURSIVE_METRICS)
   -r, --ref-rate duration        TUI refresh interval in seconds or as a Go duration string (e.g. 1s) (default 1)
   -R, --reverse                  sort in reverse order
       --shortcuts stringArray    paths to shortcut config files to load (env: PC_SHORTCUTS_FILES) (default [/home/<user>/.config/process-compose/shortcuts.yml])

--- a/www/docs/cli/process-compose.md
+++ b/www/docs/cli/process-compose.md
@@ -14,6 +14,7 @@ process-compose [flags]
   -D, --detached                 run process-compose in detached mode
       --detached-with-tui        run process-compose in detached mode with TUI
       --disable-dotenv           disable .env file loading (env: PC_DISABLE_DOTENV=1)
+      --dry-run                  validate the config and exit
   -e, --env stringArray          path to env files to load (default [.env])
   -h, --help                     help for process-compose
   -d, --hide-disabled            hide disabled processes (env: PC_HIDE_DISABLED_PROC)
@@ -28,7 +29,7 @@ process-compose [flags]
       --recursive-metrics        collect metrics recursively (env: PC_RECURSIVE_METRICS)
   -r, --ref-rate duration        TUI refresh interval in seconds or as a Go duration string (e.g. 1s) (default 1)
   -R, --reverse                  sort in reverse order
-      --shortcuts stringArray    paths to shortcut config files to load (env: PC_SHORTCUTS_FILES) (default [/home/<user>/.config/process-compose/shortcuts.yml])
+      --shortcuts stringArray    paths to shortcut config files to load (env: PC_SHORTCUTS_FILES)
       --slow-ref-rate duration   Slow(er) refresh interval for resources (CPU, RAM) in seconds or as a Go duration string (e.g. 1s). The value should be higher than --ref-rate (default 1)
   -S, --sort string              sort column name. legal values (case insensitive): [AGE, CPU, EXIT, HEALTH, MEM, NAME, NAMESPACE, PID, RESTARTS, STATUS] (default "NAME")
       --theme string             select process compose theme (default "Default")

--- a/www/docs/cli/process-compose_up.md
+++ b/www/docs/cli/process-compose_up.md
@@ -20,6 +20,7 @@ process-compose up [PROCESS...] [flags]
   -D, --detached                 run process-compose in detached mode
       --detached-with-tui        run process-compose in detached mode with TUI
       --disable-dotenv           disable .env file loading (env: PC_DISABLE_DOTENV=1)
+      --dry-run                  validate the config and exit
   -e, --env stringArray          path to env files to load (default [.env])
   -h, --help                     help for up
   -d, --hide-disabled            hide disabled processes (env: PC_HIDE_DISABLED_PROC)

--- a/www/docs/cli/process-compose_up.md
+++ b/www/docs/cli/process-compose_up.md
@@ -15,25 +15,26 @@ process-compose up [PROCESS...] [flags]
 ### Options
 
 ```
-  -f, --config stringArray      path to config files to load (env: PC_CONFIG_FILES)
-      --detach-on-success       detach the process-compose TUI after successful startup. Requires --detached-with-tui
-  -D, --detached                run process-compose in detached mode
-      --detached-with-tui       run process-compose in detached mode with TUI
-      --disable-dotenv          disable .env file loading (env: PC_DISABLE_DOTENV=1)
-  -e, --env stringArray         path to env files to load (default [.env])
-  -h, --help                    help for up
-  -d, --hide-disabled           hide disabled processes (env: PC_HIDE_DISABLED_PROC)
-      --keep-project            keep the project running even after all processes exit
-      --logs-truncate           truncate process logs buffer on startup
-  -n, --namespace stringArray   run only specified namespaces (default all)
-      --no-deps                 don't start dependent processes
-  -r, --ref-rate duration       TUI refresh interval in seconds or as a Go duration string (e.g. 1s) (default 1)
-  -R, --reverse                 sort in reverse order
-      --shortcuts stringArray   paths to shortcut config files to load (env: PC_SHORTCUTS_FILES) (default [/home/<user>/.config/process-compose/shortcuts.yml])
+  -f, --config stringArray       path to config files to load (env: PC_CONFIG_FILES)
+      --detach-on-success        detach the process-compose TUI after successful startup. Requires --detached-with-tui
+  -D, --detached                 run process-compose in detached mode
+      --detached-with-tui        run process-compose in detached mode with TUI
+      --disable-dotenv           disable .env file loading (env: PC_DISABLE_DOTENV=1)
+  -e, --env stringArray          path to env files to load (default [.env])
+  -h, --help                     help for up
+  -d, --hide-disabled            hide disabled processes (env: PC_HIDE_DISABLED_PROC)
+      --keep-project             keep the project running even after all processes exit
+      --logs-truncate            truncate process logs buffer on startup
+  -n, --namespace stringArray    run only specified namespaces (default all)
+      --no-deps                  don't start dependent processes
+      --recursive-metrics        collect metrics recursively (env: PC_RECURSIVE_METRICS)
+  -r, --ref-rate duration        TUI refresh interval in seconds or as a Go duration string (e.g. 1s) (default 1)
+  -R, --reverse                  sort in reverse order
+      --shortcuts stringArray    paths to shortcut config files to load (env: PC_SHORTCUTS_FILES)
       --slow-ref-rate duration   Slow(er) refresh interval for resources (CPU, RAM) in seconds or as a Go duration string (e.g. 1s). The value should be higher than --ref-rate (default 1)
-  -S, --sort string             sort column name. legal values (case insensitive): [AGE, CPU, EXIT, HEALTH, MEM, NAME, NAMESPACE, PID, RESTARTS, STATUS] (default "NAME")
-      --theme string            select process compose theme (default "Default")
-  -t, --tui                     enable TUI (disable with -t=false) (env: PC_DISABLE_TUI) (default true)
+  -S, --sort string              sort column name. legal values (case insensitive): [AGE, CPU, EXIT, HEALTH, MEM, NAME, NAMESPACE, PID, RESTARTS, STATUS] (default "NAME")
+      --theme string             select process compose theme (default "Default")
+  -t, --tui                      enable TUI (disable with -t=false) (env: PC_DISABLE_TUI) (default true)
 ```
 
 ### Options inherited from parent commands
@@ -51,3 +52,4 @@ process-compose up [PROCESS...] [flags]
 ### SEE ALSO
 
 * [process-compose](process-compose.md)	 - Processes scheduler and orchestrator
+


### PR DESCRIPTION
Most of the projects I am using process compose with have upwards of 10 processes. Having each instance of process compose take about 1 CPU just for management isn't scalable, alas, since I need to have 2 or 3 projects running concurrently for development. This PR makes optional being able to disable the accurate metrics gathering.

resolve #341
