### PR TITLE
fix: reverse shutdown order does not contain all dependencies

### DIFF
--- a/fixtures-code/process-compose-shutdown-inorder.yaml
+++ b/fixtures-code/process-compose-shutdown-inorder.yaml
@@ -16,8 +16,11 @@ processes:
       echo "B: starting"
       sleep 3
     depends_on:
-      procA:
+      procC:
         condition: process_started
+      procD:
+        condition: process_started
+
 
   procC:
     command: |
@@ -25,5 +28,14 @@ processes:
       echo "C: starting"
       sleep 3
     depends_on:
-      procB:
+      procA:
+        condition: process_started
+
+  procD:
+    command: |
+      trap 'echo "D: exit"' SIGTERM
+      echo "D: starting"
+      sleep 3
+    depends_on:
+      procA:
         condition: process_started

--- a/src/app/project_runner.go
+++ b/src/app/project_runner.go
@@ -478,9 +478,9 @@ func (p *ProjectRunner) runningProcessesReverseDependencies() map[string]map[str
 			if runningProc, ok := p.runningProcesses[k]; ok {
 				if _, ok := reverseDependencies[runningProc.getName()]; !ok {
 					dep := make(map[string]*Process)
-					dep[process.getName()] = process
 					reverseDependencies[runningProc.getName()] = dep
 				}
+                reverseDependencies[runningProc.getName()][process.getName()] = process
 			} else {
 				continue
 			}

--- a/src/app/system_test.go
+++ b/src/app/system_test.go
@@ -529,9 +529,11 @@ func TestSystem_TestProcListShutsDownInOrder(t *testing.T) {
 				order = append(order, line)
 			}
 		}
-		wantOrder := []string{"B: exit", "D: exit", "C: exit", "A: exit"}
-		if !slices.Equal(order, wantOrder) {
-			t.Errorf("content = %v, want %v", order, wantOrder)
+        //the order if first D or C exits is not defined
+		wantOrder1 := []string{"B: exit", "D: exit", "C: exit", "A: exit"}
+		wantOrder2 := []string{"B: exit", "C: exit", "D: exit", "A: exit"}
+		if !(slices.Equal(order, wantOrder1) || slices.Equal(order, wantOrder2)) {
+			t.Errorf("content = %v, want %v or %v", order, wantOrder1, wantOrder2)
 			return
 		}
 	})

--- a/src/app/system_test.go
+++ b/src/app/system_test.go
@@ -495,7 +495,7 @@ func TestSystem_TestProcListShutsDownInOrder(t *testing.T) {
 			t.Error(err.Error())
 			return
 		}
-		want := 3
+		want := 4
 		if len(states.States) != want {
 			t.Errorf("len(states.States) = %d, want %d", len(states.States), want)
 		}
@@ -529,7 +529,7 @@ func TestSystem_TestProcListShutsDownInOrder(t *testing.T) {
 				order = append(order, line)
 			}
 		}
-		wantOrder := []string{"C: exit", "B: exit", "A: exit"}
+		wantOrder := []string{"B: exit", "D: exit", "C: exit", "A: exit"}
 		if !slices.Equal(order, wantOrder) {
 			t.Errorf("content = %v, want %v", order, wantOrder)
 			return


### PR DESCRIPTION
This bug affects the shutdown order when multiple dependencies and the option  `--ordered-shutdow ` are used. This change fixes the `reverseDependencies` list to include all dependencies and the shutdown order then works smoothly with multiple dependencies.