### PR TITLE
Fix: if a process will never be ready, its dependants should fail

### DIFF
--- a/fixtures/process-compose-dependent-on-failing-log-line.yml
+++ b/fixtures/process-compose-dependent-on-failing-log-line.yml
@@ -1,0 +1,14 @@
+log_level: debug
+processes:
+  failer:
+    description: Halts and catches fire
+    command: "exit 1"
+    ready_log_line: "ready to accept connections"
+    availability:
+      restart: "exit_on_failure"
+  oblivious:
+    description: Tries to do setup after "failer" is ready (it will never be)
+    command: "echo All good"
+    depends_on:
+      failer:
+        condition: process_log_ready

--- a/src/app/process.go
+++ b/src/app/process.go
@@ -398,6 +398,9 @@ func (p *Process) stopProcess(cancelReadinessFuncs bool) error {
 		if p.isOneOfStates(types.ProcessStatePending) {
 			p.onProcessEnd(types.ProcessStateTerminating)
 		}
+		if cancelReadinessFuncs {
+			p.readyLogCancelFn(fmt.Errorf("process completed, cannot produce log lines"))
+		}
 		return nil
 	}
 	p.setState(types.ProcessStateTerminating)


### PR DESCRIPTION
You can see this in more detail with the fixture I provided, but if a process has a `ready_log_line` which can never be reached (process is already completed), then its dependents should not get stuck waiting for it to be ready.

I don't know if this patch really adequately covers all the use cases it ought to cover, but it covers the one in the fixture, which is representative of my use case. If I _have_ missed any related scenarios, let's figure out what we need to do to cover them, tests included!