### PR TITLE
app, config: Obey parentOnly for Windows and add same log as for Unix and fix forceKillOnTimeout

### DIFF
--- a/src/app/process.go
+++ b/src/app/process.go
@@ -436,7 +436,7 @@ func (p *Process) forceKillOnTimeout() error {
 		return nil
 	case errors.Is(err, context.DeadlineExceeded):
 		log.Debug().Msgf("process failed to shut down within %d seconds, sending %d", p.procConf.ShutDownParams.ShutDownTimeout, syscall.SIGKILL)
-		return p.command.Stop(int(syscall.SIGKILL), p.procConf.ShutDownParams.ParentOnly)
+		return p.command.Stop(int(syscall.SIGKILL), false)
 	default:
 		log.Error().Err(err).Msgf("terminating %s with timeout %d failed", p.getName(), p.procConf.ShutDownParams.ShutDownTimeout)
 		return err

--- a/src/command/stopper_windows.go
+++ b/src/command/stopper_windows.go
@@ -14,10 +14,10 @@ func (c *CmdWrapper) Stop(sig int, parentOnly bool) error {
 		Msg("Stop Windows process.")
 
 	if parentOnly {
-		kill := exec.Command("TASKKILL", "/F", "/PID", strconv.Itoa(c.Pid()))
+		kill := exec.Command("C:\Windows\System32\taskkill.exe", "/F", "/PID", strconv.Itoa(c.Pid()))
 		return kill.Run()
 	}
-	kill := exec.Command("TASKKILL", "/T", "/F", "/PID", strconv.Itoa(c.Pid()))
+	kill := exec.Command("C:\Windows\System32\taskkill.exe", "/T", "/F", "/PID", strconv.Itoa(c.Pid()))
 	return kill.Run()
 }
 

--- a/src/command/stopper_windows.go
+++ b/src/command/stopper_windows.go
@@ -5,8 +5,18 @@ import (
 	"strconv"
 )
 
-func (c *CmdWrapper) Stop(sig int, _parentOnly bool) error {
+func (c *CmdWrapper) Stop(sig int, parentOnly bool) error {
 	//p.command.Process.Kill()
+	log.
+		Debug().
+		Int("pid", c.Pid()).
+		Bool("parentOnly", parentOnly).
+		Msg("Stop Windows process.")
+
+	if parentOnly {
+		kill := exec.Command("TASKKILL", "/F", "/PID", strconv.Itoa(c.Pid()))
+		return kill.Run()
+	}
 	kill := exec.Command("TASKKILL", "/T", "/F", "/PID", strconv.Itoa(c.Pid()))
 	return kill.Run()
 }


### PR DESCRIPTION
- Obey parentOnly for Windows and add same log as for Unix
- In case of shutdown timeout, per [docs](https://github.com/F1bonacc1/process-compose/blob/main/www/docs/launcher.md?plain=1#L176), the process group should receive the `SIGKILL` signal (irrespective of the `shutdown.parent_only` option)