### PR TITLE
chore(schema): fixed process compose schema(based on realworld configs) and swagger API desync with code

### DIFF
--- a/schemas/process-compose-schema.json
+++ b/schemas/process-compose-schema.json
@@ -249,9 +249,13 @@
     "ProcessDependency": {
       "properties": {
         "condition": {
-          "oneOf": [
-            { "type": "integer", "enum": [0, 1, 2, 3] },
-            { "type": "string", "enum": ["process_started", "process_healthy", "process_completed", "process_completed_successfully"] }
+          "type": "string",
+          "enum": [
+            "process_started",
+            "process_healthy",
+            "process_completed",
+            "process_completed_successfully",
+            "process_log_ready"
           ]
         }
       },
@@ -343,11 +347,14 @@
     "RestartPolicyConfig": {
       "properties": {
         "restart": {
-          "oneOf": [
-            { "type": "integer", "enum": [0, 1, 2, 3] },
-            { "type": "string", "enum": ["no", "always", "on_failure", "exit_on_failure"] }
+          "type": "string",
+          "enum": [
+            "always",
+            "on_failure",
+            "exit_on_failure",
+            "no"
           ]
-        },  
+        },
         "backoff_seconds": {
           "type": "integer"
         },

--- a/schemas/process-compose-schema.json
+++ b/schemas/process-compose-schema.json
@@ -244,15 +244,15 @@
           "type": "array"
         }
       },
-      "type": "object",
-      "required": [
-        "name"
-      ]
+      "type": "object"
     },
     "ProcessDependency": {
       "properties": {
         "condition": {
-          "type": "integer"
+          "oneOf": [
+            { "type": "integer", "enum": [0, 1, 2, 3] },
+            { "type": "string", "enum": ["process_started", "process_healthy", "process_completed", "process_completed_successfully"] }
+          ]
         }
       },
       "type": "object"
@@ -337,15 +337,17 @@
       },
       "type": "object",
       "required": [
-        "version",
         "processes"
       ]
     },
     "RestartPolicyConfig": {
       "properties": {
         "restart": {
-          "type": "integer"
-        },
+          "oneOf": [
+            { "type": "integer", "enum": [0, 1, 2, 3] },
+            { "type": "string", "enum": ["no", "always", "on_failure", "exit_on_failure"] }
+          ]
+        },  
         "backoff_seconds": {
           "type": "integer"
         },

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,19 @@ pkgs.mkShell {
       goLine = builtins.elemAt (pkgs.lib.splitString "\n" goMod) 2;
       goLineMapped = builtins.replaceStrings [ " " "." ] [ "_" "_" ] goLine;
       go = pkgs."${goLineMapped}";
+      swag2op = pkgs.buildGoModule {
+        pname = "swag2op";
+        version = "v1.0.1";
+        src = pkgs.fetchFromGitHub {
+          owner = "zxmfke";
+          repo = "swagger2openapi3";
+          rev = "17d7e5a8f5e12164d3a455f179638c5208869272";
+          sha256 = "sha256-0khXtJ2DB56RLMwPU61K/OQld0w16YxPj89AZ31U3yo=";
+        };
+        subPackages = [ "cmd/swag2op" ];
+        vendorHash = "sha256-y6evAKRDgUChEFwVjTIis1aaMJb8sbvRZwIyHyspy3c=";
+        doCheck = false;
+      };
     in
     with pkgs;
     [
@@ -16,5 +29,6 @@ pkgs.mkShell {
       gotools
       gnumake
       gnused
+      swag2op
     ];
 }

--- a/src/api/pc_api.go
+++ b/src/api/pc_api.go
@@ -376,7 +376,8 @@ func (api *PcApi) UpdateProject(c *gin.Context) {
 // @Description	Update process
 // @Tags			Process
 // @Summary		Updates process configuration
-// @Produce		json
+// @Accept			json
+// @Param			process	body	types.ProcessConfig	true	"Process configuration to update"
 // @Success		200	{object}	types.ProcessConfig	"Updated Process Config"
 // @Failure		400	{object}	map[string]string
 // @Router			/process [post]

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -46,6 +46,9 @@ const docTemplate = `{
         "/process": {
             "post": {
                 "description": "Update process",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -54,6 +57,17 @@ const docTemplate = `{
                 ],
                 "summary": "Updates process configuration",
                 "operationId": "UpdateProcess",
+                "parameters": [
+                    {
+                        "description": "Process configuration to update",
+                        "name": "process",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.ProcessConfig"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Updated Process Config",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -564,6 +564,18 @@
             "post": {
                 "description": "Update process",
                 "operationId": "UpdateProcess",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.ProcessConfig"
+                            }
+                        }
+                    },
+                    "description": "Process configuration to update",
+                    "required": true,
+                    "x-originalParamName": "process"
+                },
                 "responses": {
                     "200": {
                         "content": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -381,6 +381,14 @@ paths:
         post:
             description: Update process
             operationId: UpdateProcess
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/types.ProcessConfig'
+                description: Process configuration to update
+                required: true
+                x-originalParamName: process
             responses:
                 "200":
                     content:

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -23,7 +23,7 @@ type (
 	Environment   []string
 	EnvCmd        map[string]string
 	ProcessConfig struct {
-		Name              string
+		Name              string                 `yaml:",omitempty"`
 		Disabled          bool                   `yaml:"disabled,omitempty"`
 		IsDaemon          bool                   `yaml:"is_daemon,omitempty"`
 		Command           string                 `yaml:"command,omitempty"`
@@ -354,7 +354,7 @@ const (
 )
 
 type RestartPolicyConfig struct {
-	Restart        RestartPolicy `yaml:",omitempty"`
+	Restart        RestartPolicy `yaml:",omitempty" jsonschema:"type=string,enum=always,enum=on_failure,enum=exit_on_failure,enum=no"`
 	BackoffSeconds int           `yaml:"backoff_seconds,omitempty"`
 	MaxRestarts    int           `yaml:"max_restarts,omitempty"`
 	ExitOnEnd      bool          `yaml:"exit_on_end,omitempty"`
@@ -410,7 +410,7 @@ func (c *ProcessCondition) UnmarshalYAML(node *yaml.Node) error {
 type DependsOnConfig map[string]ProcessDependency
 
 type ProcessDependency struct {
-	Condition  ProcessCondition       `yaml:",omitempty"`
+	Condition  ProcessCondition       `yaml:",omitempty" jsonschema:"type=string,enum=process_started,enum=process_healthy,enum=process_completed,enum=process_completed_successfully,enum=process_log_ready"`
 	Extensions map[string]interface{} `yaml:",inline"`
 }
 

--- a/src/types/project.go
+++ b/src/types/project.go
@@ -2,14 +2,15 @@ package types
 
 import (
 	"fmt"
-	"github.com/f1bonacc1/process-compose/src/command"
 	"sort"
+
+	"github.com/f1bonacc1/process-compose/src/command"
 )
 
 type Vars map[string]any
 
 type Project struct {
-	Version             string               `yaml:"version"`
+	Version             string               `yaml:",omitempty"`
 	Name                string               `yaml:"name,omitempty"`
 	LogLocation         string               `yaml:"log_location,omitempty"`
 	LogLevel            string               `yaml:"log_level,omitempty"`


### PR DESCRIPTION
Next config is valid and runs well by latest process compose:
```json
{
    "log_location": "/tmp/n1-services/nord-deps/pc.log",
    "processes": {
        "hist": {
            "availability": {
                "max_restarts": 5,
                "restart": "on_failure"
            },
            "command": "/nix/store/vjbbbnj3pjqfxg25fln5na6pv581h4a9-start-postgres/bin/start-postgres",
            "depends_on": {
                "hist-init": {
                    "condition": "process_completed_successfully"
                }
            },
            "namespace": "postgres.hist",
            "readiness_probe": {
                "exec": {
                    "command": "/nix/store/zzyl3swwn6flq975s025csl1mr3lqzq2-postgresql-and-plugins-17.5/bin/pg_isready -h 127.0.0.1 -p 5432 -d template1 -U postgres"
                },
                "failure_threshold": 5,
                "initial_delay_seconds": 2,
                "period_seconds": 10,
                "success_threshold": 1,
                "timeout_seconds": 4
            },
            "shutdown": {
                "signal": 2
            }
        },
        "hist-init": {
            "command": "/nix/store/rjj8nksl2jamj0izy6ln4v1szrd3f6f2-setup-postgres/bin/setup-postgres",
            "namespace": "postgres.hist"
        }
    },
    "shell": {
        "shell_argument": "-c",
        "shell_command": "/nix/store/0nxvi9r5ymdlr2p24rjj9qzyms72zld1-bash-interactive-5.2p37/bin/bash"
    }
}
```

Yet, schema rejects it. 

Also made enums to work too. And made all variants into.

So making it to be success on validation.

So schema adheres reality.