### PR TITLE
chore(git): light isolation for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ www/.cache
 
 Cargo.lock
 target
+
+.gochache
+.gomodcache


### PR DESCRIPTION
by default codex "isolates"(very light) its action to current directory.

while some go commands try to modify external directories.

so codex by defaults gets some Go files, and i ignore them.