### PR TITLE
docs: fix typo in condition

### DIFF
--- a/www/docs/launcher.md
+++ b/www/docs/launcher.md
@@ -255,7 +255,7 @@ processes:
     command: "go test ./..."
     depends_on:
       sanitycheck:
-        condition: process_completed_successfuly
+        condition: process_completed_successfully
 ```
 
 ## Terminate Process Compose once given process ends


### PR DESCRIPTION
Stumbled upon a typo on [https://f1bonacc1.github.io/process-compose/launcher/](https://f1bonacc1.github.io/process-compose/launcher/)