### PR TITLE
fix: read `PC_ADDRESS` env var

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -93,7 +93,7 @@ func init() {
 	rootCmd.Flags().VarP(refreshRateFlag{pcFlags.RefreshRate}, "ref-rate", "r", "TUI refresh interval in seconds or as a Go duration string (e.g. 1s)")
 	rootCmd.Flags().Var(refreshRateFlag{pcFlags.SlowRefreshRate}, "slow-ref-rate", "Slow(er) refresh interval for resources (CPU, RAM) in seconds or as a Go duration string (e.g. 1s). The value should be higher than --ref-rate")
 	rootCmd.PersistentFlags().IntVarP(pcFlags.PortNum, "port", "p", *pcFlags.PortNum, "port number (env: "+config.EnvVarNamePort+")")
-	rootCmd.PersistentFlags().StringVar(pcFlags.Address, "address", "", "address to listen on (env: "+config.EnvVarNameAddress+")")
+	rootCmd.PersistentFlags().StringVarP(pcFlags.Address, "address", "", *pcFlags.Address, "address to listen on (env: "+config.EnvVarNameAddress+")")
 	rootCmd.Flags().StringArrayVarP(&opts.FileNames, "config", "f", config.GetConfigDefault(), "path to config files to load (env: "+config.EnvVarNameConfig+")")
 	rootCmd.Flags().StringArrayVarP(&opts.EnvFileNames, "env", "e", []string{".env"}, "path to env files to load")
 	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", nil, "run only specified namespaces (default all)")

--- a/src/config/Flags.go
+++ b/src/config/Flags.go
@@ -99,7 +99,7 @@ func NewFlags() *Flags {
 		SlowRefreshRate:      toPtr(DefaultRefreshRate),
 		IsTuiEnabled:         toPtr(getDisableTuiDefault()),
 		PortNum:              toPtr(getPortDefault()),
-		Address:              toPtr(DefaultAddress),
+		Address:              toPtr(getAddressDefault()),
 		LogLength:            toPtr(DefaultLogLength),
 		LogLevel:             toPtr(DefaultLogLevel),
 		LogFile:              toPtr(GetLogFilePath()),

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -132,6 +132,14 @@ func getNoServerDefault() bool {
 	return found
 }
 
+func getAddressDefault() string {
+	val, found := os.LookupEnv(EnvVarNameAddress)
+	if found {
+		return val
+	}
+	return DefaultAddress
+}
+
 func getPortDefault() int {
 	val, found := os.LookupEnv(EnvVarNamePort)
 	if found {


### PR DESCRIPTION
It looks like this change should have been part of https://github.com/F1bonacc1/process-compose/commit/67feadcc4118476f8fcc5420f27df8ad435a05e5, which added `--address` and documented `PC_ADDRESS`, but didn't actually read it from the environment.