### PR TITLE
fix: go.mod parses to 1_24_0 instead of nixpkg's 1_24

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,14 @@
       };
     in
     (flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          (self: super: {
+            go_1_24_0 = super.go_1_24;
+          })
+        ];
+      };
     in {
         packages.process-compose = mkPackage pkgs;
         defaultPackage = self.packages."${system}".process-compose;


### PR DESCRIPTION
This overlay allows our `swag2op` Go module to map to Go 1.24.0 (whose nixpkg entry is `go_1_24` instead of `go_1_24_0` which we generate)  