### PR TITLE
feat: Add Restart All Processes functionality

### DIFF
--- a/src/api/pc_api.go
+++ b/src/api/pc_api.go
@@ -251,6 +251,25 @@ func (api *PcApi) RestartProcess(c *gin.Context) {
 }
 
 // @Schemes
+// @Id				RestartAllProcesses
+// @Description	Restarts all processes
+// @Tags			Process
+// @Summary		Restart all processes
+// @Produce		json
+// @Success		200	{object}	api.StatusResponse	"Restart All Status"
+// @Failure		400	{object}	map[string]string
+// @Router			/processes/restart [post]
+func (api *PcApi) RestartAllProcesses(c *gin.Context) {
+	err := api.project.RestartAllProcesses()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "restarted"})
+}
+
+// @Schemes
 // @Id				ScaleProcess
 // @Description	Scale a process
 // @Tags			Process

--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -36,6 +36,7 @@ func InitRoutes(useLogger bool, handler *PcApi) *gin.Engine {
 	r.PATCH("/processes/stop", handler.StopProcesses)
 	r.POST("/process/start/:name", handler.StartProcess)
 	r.POST("/process/restart/:name", handler.RestartProcess)
+	r.POST("/processes/restart", handler.RestartAllProcesses)
 	r.POST("/project/stop", handler.ShutDownProject)
 	r.POST("/project", handler.UpdateProject)
 	r.POST("/project/configuration", handler.ReloadProject)

--- a/src/app/project_interface.go
+++ b/src/app/project_interface.go
@@ -28,6 +28,7 @@ type IProject interface {
 	StopProcesses(names []string) (map[string]string, error)
 	StartProcess(name string) error
 	RestartProcess(name string) error
+	RestartAllProcesses() error
 	ScaleProcess(name string, scale int) error
 	GetProcessPorts(name string) (*types.ProcessPorts, error)
 	SetProcessPassword(name string, password string) error

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -132,6 +132,10 @@ func (p *PcClient) RestartProcess(name string) error {
 	return p.restartProcess(name)
 }
 
+func (p *PcClient) RestartAllProcesses() error {
+	return p.restartAllProcesses()
+}
+
 func (p *PcClient) ScaleProcess(name string, scale int) error {
 	return p.scaleProcess(name, scale)
 }

--- a/src/client/restart.go
+++ b/src/client/restart.go
@@ -33,10 +33,10 @@ func (p *PcClient) restartAllProcesses() error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
 		return nil
 	}
-	defer resp.Body.Close()
 	var respErr pcError
 	if err = json.NewDecoder(resp.Body).Decode(&respErr); err != nil {
 		log.Error().Msgf("failed to decode restart all processes response: %v", err)

--- a/src/client/restart.go
+++ b/src/client/restart.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"net/http"
+
+	"github.com/rs/zerolog/log"
 )
 
 func (p *PcClient) restartProcess(name string) error {
@@ -21,6 +22,24 @@ func (p *PcClient) restartProcess(name string) error {
 	var respErr pcError
 	if err = json.NewDecoder(resp.Body).Decode(&respErr); err != nil {
 		log.Error().Msgf("failed to decode restart process %s response: %v", name, err)
+		return err
+	}
+	return errors.New(respErr.Error)
+}
+
+func (p *PcClient) restartAllProcesses() error {
+	url := fmt.Sprintf("http://%s/processes/restart", p.address)
+	resp, err := p.client.Post(url, "application/json", nil)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	defer resp.Body.Close()
+	var respErr pcError
+	if err = json.NewDecoder(resp.Body).Decode(&respErr); err != nil {
+		log.Error().Msgf("failed to decode restart all processes response: %v", err)
 		return err
 	}
 	return errors.New(respErr.Error)

--- a/src/tui/actions.go
+++ b/src/tui/actions.go
@@ -25,6 +25,7 @@ const (
 	ActionProcessInfo      = ActionName("process_info")
 	ActionProcessStop      = ActionName("process_stop")
 	ActionProcessRestart   = ActionName("process_restart")
+	ActionProcessRestartAll = ActionName("process_restart_all")
 	ActionProcessScreen    = ActionName("process_screen")
 	ActionQuit             = ActionName("quit")
 	ActionLogFind          = ActionName("find")
@@ -57,6 +58,7 @@ var defaultShortcuts = map[ActionName]tcell.Key{
 	ActionProcessStart:     tcell.KeyF7,
 	ActionProcessStop:      tcell.KeyF9,
 	ActionProcessRestart:   tcell.KeyCtrlR,
+	ActionProcessRestartAll: tcell.KeyCtrlU,
 	ActionProcessScreen:    tcell.KeyF8,
 	ActionQuit:             tcell.KeyF10,
 	ActionLogFind:          tcell.KeyCtrlF,
@@ -109,6 +111,7 @@ var procActionsOrder = []ActionName{
 	ActionProcessScreen,
 	ActionProcessStop,
 	ActionProcessRestart,
+	ActionProcessRestartAll,
 	ActionEditProcess,
 	ActionReloadConfig,
 	ActionNsFilter,
@@ -341,6 +344,9 @@ func newShortCuts() *ShortCuts {
 			},
 			ActionProcessRestart: {
 				Description: "Restart",
+			},
+			ActionProcessRestartAll: {
+				Description: "Restart All",
 			},
 			ActionQuit: {
 				Description: "Quit",

--- a/src/tui/all-logs-observer.go
+++ b/src/tui/all-logs-observer.go
@@ -1,0 +1,73 @@
+package tui
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math"
+
+	"github.com/f1bonacc1/process-compose/src/pclog"
+)
+
+// tviewColors is a list of tview color names for process name prefixes.
+var tviewColors = []string{
+	"red",
+	"green",
+	"yellow",
+	"blue",
+	"magenta",
+	"cyan",
+	"orange",
+	"pink",
+	"lime",
+	"aqua",
+	"violet",
+	"gold",
+}
+
+// getProcessColor returns a tview color name for the given process name.
+func getProcessColor(name string) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(name))
+	return tviewColors[int(hash.Sum32())%len(tviewColors)]
+}
+
+// AllLogsObserver wraps a LogView and prefixes log lines with a colored process name.
+// It implements pclog.LogObserver interface.
+type AllLogsObserver struct {
+	processName string
+	logView     *LogView
+	color       string
+	uniqueID    string
+}
+
+// NewAllLogsObserver creates a new AllLogsObserver for the given process.
+func NewAllLogsObserver(processName string, logView *LogView) *AllLogsObserver {
+	return &AllLogsObserver{
+		processName: processName,
+		logView:     logView,
+		color:       getProcessColor(processName),
+		uniqueID:    pclog.GenerateUniqueID(10),
+	}
+}
+
+// WriteString writes a log line prefixed with the colored process name.
+func (o *AllLogsObserver) WriteString(line string) (n int, err error) {
+	return o.logView.WriteStringWithProcess(line, o.processName, o.color)
+}
+
+// SetLines sets multiple log lines, each prefixed with the colored process name.
+func (o *AllLogsObserver) SetLines(lines []string) {
+	for _, line := range lines {
+		_, _ = o.WriteString(line)
+	}
+}
+
+// GetTailLength returns the tail length for log subscription.
+func (o *AllLogsObserver) GetTailLength() int {
+	return math.MaxInt
+}
+
+// GetUniqueID returns the unique identifier for this observer.
+func (o *AllLogsObserver) GetUniqueID() string {
+	return fmt.Sprintf("all-logs-%s-%s", o.processName, o.uniqueID)
+}

--- a/src/tui/log-viewer.go
+++ b/src/tui/log-viewer.go
@@ -40,7 +40,6 @@ type LogView struct {
 }
 
 func NewLogView(maxLines int) *LogView {
-
 	l := &LogView{
 		isWrapOn: true,
 		TextView: *tview.NewTextView().
@@ -74,6 +73,12 @@ func (l *LogView) WriteString(line string) (n int, err error) {
 	} else {
 		return fmt.Fprintf(l.buffer, "%s\n", tview.Escape(line))
 	}
+}
+
+// WriteStringWithProcess writes a log line prefixed with a colored process name.
+func (l *LogView) WriteStringWithProcess(line, processName, color string) (n int, err error) {
+	// Use tview color tags: [color]text[-:-:-]
+	return fmt.Fprintf(l.buffer, "[%s][%s][-:-:-] %s\n", color, tview.Escape(processName), tview.Escape(line))
 }
 
 func (l *LogView) AddLines(lines []string) {
@@ -205,4 +210,3 @@ func (l *LogView) AddMark() {
 func (l *LogView) setTruncator(t truncator) {
 	l.truncator = t
 }
-

--- a/src/tui/proc-table.go
+++ b/src/tui/proc-table.go
@@ -31,9 +31,7 @@ type tableRowValues struct {
 	exitCode  string
 }
 
-var (
-	DetachOnSuccessMessage = "All processes started successfully, detached from TUI"
-)
+var DetachOnSuccessMessage = "All processes started successfully, detached from TUI"
 
 func (pv *pcView) fillTableData() {
 	if pv.project == nil {
@@ -148,7 +146,26 @@ func setRowValues(procTable *tview.Table, row int, rowVals tableRowValues) {
 	procTable.SetCell(row, int(ProcessStateExit), tview.NewTableCell(rowVals.exitCode).SetAlign(tview.AlignRight).SetExpansion(0).SetTextColor(rowVals.fgColor))
 }
 
-func (pv *pcView) onTableSelectionChange(_, _ int) {
+func (pv *pcView) onTableSelectionChange(row, _ int) {
+	// Header row selected - show all logs
+	if row == 0 {
+		if !pv.allLogsMode {
+			pv.allLogsMode = true
+			pv.logsText.resetSearch()
+			pv.unFollowLog()
+			pv.followAllLogs()
+			pv.logsText.SetTitle(pv.getLogTitle(""))
+			pv.updateHelpTextView()
+		}
+		return
+	}
+
+	// Process row selected - exit all-logs mode if active
+	if pv.allLogsMode {
+		pv.allLogsMode = false
+		pv.unFollowAllLogs()
+	}
+
 	name := pv.getSelectedProcName()
 	if len(name) == 0 {
 		return
@@ -256,11 +273,9 @@ func (pv *pcView) createProcTable() *tview.Table {
 		expansion := 10
 		align := tview.AlignLeft
 		switch ColumnID(i) {
-		case
-			ProcessStatePid:
+		case ProcessStatePid:
 			expansion = 1
-		case
-			ProcessStateIcon:
+		case ProcessStateIcon:
 			expansion = 1
 			align = tview.AlignCenter
 		case
@@ -270,7 +285,7 @@ func (pv *pcView) createProcTable() *tview.Table {
 		}
 
 		table.SetCell(0, i, tview.NewTableCell(pv.procColumns[ColumnID(i)]).
-			SetSelectable(false).SetExpansion(expansion).SetAlign(align))
+			SetSelectable(true).SetExpansion(expansion).SetAlign(align))
 	}
 	table.SetSelectionChangedFunc(pv.onTableSelectionChange)
 	return table
@@ -435,7 +450,6 @@ func byteCountIEC(b int64) string {
 	const mib = 1024 * 1024
 	if b < mib {
 		return fmt.Sprintf("%.1f MiB", float64(b)/float64(mib))
-
 	}
 	const unit = 1024
 	div, exp := int64(1024), 0

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -303,6 +303,9 @@ func (pv *pcView) setShortCutsActions() {
 		}
 		pv.showPassIfNeeded()
 	})
+	pv.shortcuts.setAction(ActionProcessRestartAll, func() {
+		go pv.handleRestartAll()
+	})
 	pv.shortcuts.setAction(ActionDependencyGraph, pv.showGraphDialog)
 }
 
@@ -539,6 +542,7 @@ func (pv *pcView) updateHelpTextView() {
 		pv.shortcuts.addToggleButton(ActionProcessScreen, pv.helpFooter, procScrBool)
 		pv.shortcuts.addButton(ActionProcessStop, pv.helpFooter)
 		pv.shortcuts.addButton(ActionProcessRestart, pv.helpFooter)
+		pv.shortcuts.addButton(ActionProcessRestartAll, pv.helpFooter)
 	}
 	pv.shortcuts.addButton(ActionQuit, pv.helpFooter)
 }

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -291,6 +291,9 @@ func (pv *pcView) setShortCutsActions() {
 		}
 		pv.showPassIfNeeded()
 	})
+	pv.shortcuts.setAction(ActionProcessRestartAll, func() {
+		go pv.handleRestartAll()
+	})
 	pv.shortcuts.setAction(ActionDependencyGraph, pv.showGraphDialog)
 }
 
@@ -526,6 +529,7 @@ func (pv *pcView) updateHelpTextView() {
 	pv.shortcuts.addToggleButton(ActionProcessScreen, pv.helpFooter, procScrBool)
 	pv.shortcuts.addButton(ActionProcessStop, pv.helpFooter)
 	pv.shortcuts.addButton(ActionProcessRestart, pv.helpFooter)
+	pv.shortcuts.addButton(ActionProcessRestartAll, pv.helpFooter)
 	pv.shortcuts.addButton(ActionQuit, pv.helpFooter)
 }
 

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -23,8 +23,10 @@ import (
 	"github.com/rivo/tview"
 )
 
-type scrSplitState int
-type commandType int
+type (
+	scrSplitState int
+	commandType   int
+)
 
 const (
 	LogFull     scrSplitState = 0
@@ -100,10 +102,13 @@ type pcView struct {
 	attentionMessages      chan attentionMessage
 	attentionCancel        context.CancelFunc
 	errTuiStartup          error
+
+	// All-logs mode fields
+	allLogsMode      bool
+	allLogsObservers map[string]*AllLogsObserver
 }
 
 func newPcView(project app.IProject) *pcView {
-
 	pv := &pcView{
 		appView:        tview.NewApplication(),
 		logsText:       NewLogView(project.GetLogLength()),
@@ -131,6 +136,9 @@ func newPcView(project app.IProject) *pcView {
 		themes:            config.NewThemes(),
 		settings:          config.NewSettings(),
 		attentionMessages: make(chan attentionMessage, 10),
+
+		// All-logs mode
+		allLogsObservers: make(map[string]*AllLogsObserver),
 	}
 	pv.termView = NewTerminalView(pv.appView)
 	pv.termView.SetOnEscape(pv.changeFocus)
@@ -160,7 +168,7 @@ func newPcView(project app.IProject) *pcView {
 		pv.followLog(name)
 	}
 	go pv.startAttentionsMessageRoutine()
-	//pv.dumpStyles()
+	// pv.dumpStyles()
 	return pv
 }
 
@@ -261,7 +269,11 @@ func (pv *pcView) setShortCutsActions() {
 	})
 	pv.shortcuts.setAction(ActionClearLog, func() {
 		pv.logsText.Clear()
-		pv.truncateLog()
+		if pv.allLogsMode {
+			pv.truncateAllLogs()
+		} else {
+			pv.truncateLog()
+		}
 	})
 	pv.shortcuts.setAction(ActionMarkLog, func() {
 		pv.logsText.AddMark()
@@ -290,9 +302,6 @@ func (pv *pcView) setShortCutsActions() {
 			pv.showError(err.Error())
 		}
 		pv.showPassIfNeeded()
-	})
-	pv.shortcuts.setAction(ActionProcessRestartAll, func() {
-		go pv.handleRestartAll()
 	})
 	pv.shortcuts.setAction(ActionDependencyGraph, pv.showGraphDialog)
 }
@@ -353,10 +362,10 @@ func (pv *pcView) onMainGridKey(event *tcell.EventKey) *tcell.EventKey {
 			if !pv.isCommandModeDisabled() {
 				return event
 			}
-			return pv.shortcuts.runRuneAction(event.Rune(), event) //event
+			return pv.shortcuts.runRuneAction(event.Rune(), event) // event
 		}
 	default:
-		return pv.shortcuts.runKeyAction(event.Key(), event) //event
+		return pv.shortcuts.runKeyAction(event.Key(), event) // event
 	}
 	return nil
 }
@@ -368,7 +377,6 @@ func (pv *pcView) exitSearch() {
 }
 
 func (pv *pcView) terminateAppView() {
-
 	result := "Are you sure you want to quit?\nThis will terminate all the running processes."
 	if pv.project.IsRemote() {
 		result = "Detach from the remote project?"
@@ -522,14 +530,16 @@ func (pv *pcView) updateHelpTextView() {
 		pv.shortcuts.addToggleButton(ActionLogSelection, pv.helpFooter, !pv.logSelect)
 	}
 	pv.shortcuts.addButton(ActionLogFind, pv.helpFooter)
-	pv.shortcuts.addCategory("PROCESS:", pv.helpFooter)
-	pv.shortcuts.addButton(ActionProcessScale, pv.helpFooter)
-	pv.shortcuts.addButton(ActionProcessInfo, pv.helpFooter)
-	pv.shortcuts.addButton(ActionProcessStart, pv.helpFooter)
-	pv.shortcuts.addToggleButton(ActionProcessScreen, pv.helpFooter, procScrBool)
-	pv.shortcuts.addButton(ActionProcessStop, pv.helpFooter)
-	pv.shortcuts.addButton(ActionProcessRestart, pv.helpFooter)
-	pv.shortcuts.addButton(ActionProcessRestartAll, pv.helpFooter)
+	// Only show process-specific shortcuts when NOT in all-logs mode
+	if !pv.allLogsMode {
+		pv.shortcuts.addCategory("PROCESS:", pv.helpFooter)
+		pv.shortcuts.addButton(ActionProcessScale, pv.helpFooter)
+		pv.shortcuts.addButton(ActionProcessInfo, pv.helpFooter)
+		pv.shortcuts.addButton(ActionProcessStart, pv.helpFooter)
+		pv.shortcuts.addToggleButton(ActionProcessScreen, pv.helpFooter, procScrBool)
+		pv.shortcuts.addButton(ActionProcessStop, pv.helpFooter)
+		pv.shortcuts.addButton(ActionProcessRestart, pv.helpFooter)
+	}
 	pv.shortcuts.addButton(ActionQuit, pv.helpFooter)
 }
 
@@ -637,7 +647,6 @@ func (pv *pcView) changeFocus() {
 }
 
 func setupTui(project app.IProject, options ...Option) {
-
 	pv := newPcView(project)
 	for _, option := range options {
 		if err := option(pv); err != nil {
@@ -651,7 +660,6 @@ func setupTui(project app.IProject, options ...Option) {
 	}
 
 	pcv = pv
-
 }
 
 func RunTUIAsync(project app.IProject, options ...Option) {


### PR DESCRIPTION
A common workflow in many projects is to run a set of services, make changes, build and restart the services. In process compose TUI the only path to accomplish this is to individually restart each process which is tedious. 

This PR implements a "Restart All" shortcut that stops all of the processes and reruns them the same way it does when starting for the first time. 

The shortcut is "Ctrl+U" and is made available in the footer as well as the "Shortcuts" menu. 

Below is a summary of the changes included: 

- Implemented RestartAllProcesses method in the API and ProjectRunner.
- Added route for restarting all processes.
- Created client method to call the restart all processes API.
- Integrated restart all processes action in TUI with confirmation dialog.
- Updated shortcuts and help text for new action.

[Screencast_20260123_161747.webm](https://github.com/user-attachments/assets/e92792f3-2bdd-4e7a-bd82-7e39bccbec9a)
