### PR TITLE
feat: Send POSIX signals to processes via TUI.

### DIFF
--- a/src/api/pc_api.go
+++ b/src/api/pc_api.go
@@ -176,6 +176,34 @@ func (api *PcApi) StopProcess(c *gin.Context) {
 }
 
 // @Schemes
+// @Id				SendSignal
+// @Description	Sends a POSIX signal to the process
+// @Tags			Process
+// @Summary		Signal a process
+// @Produce		json
+// @Param			name	path		string				true	"Process Name"
+// @Param			signal	path		int					true	"Signal Number"
+// @Success		200		{object}	api.NameResponse	"Signaled Process Name"
+// @Failure		400		{object}	map[string]string
+// @Router			/process/signal/{name}/{signal} [patch]
+func (api *PcApi) SendSignal(c *gin.Context) {
+	name := c.Param("name")
+	sig, err := strconv.Atoi(c.Param("signal"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid signal"})
+		return
+	}
+
+	err = api.project.SendSignal(name, sig)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"name": name})
+}
+
+// @Schemes
 // @Id				StopProcesses
 // @Description	Sends kill signal to the processes list
 // @Tags			Process

--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -60,6 +60,7 @@ func InitRoutes(useLogger bool, handler *PcApi) *gin.Engine {
 	r.GET("/process/logs/:name/:endOffset/:limit", handler.GetProcessLogs)
 	r.DELETE("/process/logs/:name", handler.TruncateProcessLogs)
 	r.PATCH("/process/stop/:name", handler.StopProcess)
+	r.PATCH("/process/signal/:name/:signal", handler.SendSignal)
 	r.PATCH("/processes/stop", handler.StopProcesses)
 	r.POST("/process/start/:name", handler.StartProcess)
 	r.POST("/process/restart/:name", handler.RestartProcess)

--- a/src/app/process.go
+++ b/src/app/process.go
@@ -384,6 +384,13 @@ func (p *Process) internalStop() error {
 	return p.stopProcess(false)
 }
 
+func (p *Process) sendSignal(sig int) error {
+	if !p.isRunning() {
+		return fmt.Errorf("process %s is not running", p.getName())
+	}
+	return p.command.Signal(sig, p.procConf.ShutDownParams.ParentOnly)
+}
+
 func (p *Process) stopProcess(withNoRestart bool) error {
 	if withNoRestart {
 		p.runCancelFn()

--- a/src/app/project_interface.go
+++ b/src/app/project_interface.go
@@ -25,6 +25,7 @@ type IProject interface {
 	GetProcessState(name string) (*types.ProcessState, error)
 	GetProcessesState() (*types.ProcessesState, error)
 	StopProcess(name string) error
+	SendSignal(name string, sig int) error
 	StopProcesses(names []string) (map[string]string, error)
 	StartNamespace(namespace string) error
 	StopNamespace(namespace string) error

--- a/src/app/project_runner.go
+++ b/src/app/project_runner.go
@@ -488,6 +488,20 @@ func (p *ProjectRunner) StopProcess(name string) error {
 	return err
 }
 
+func (p *ProjectRunner) SendSignal(name string, sig int) error {
+	log.Info().Msgf("Sending signal %d to %s", sig, name)
+	proc := p.getRunningProcess(name)
+	if proc == nil {
+		if _, ok := p.project.Processes[name]; !ok {
+			log.Error().Msgf("Process %s does not exist", name)
+			return fmt.Errorf("process %s does not exist", name)
+		}
+		log.Error().Msgf("Process %s is not running", name)
+		return fmt.Errorf("process %s is not running", name)
+	}
+	return proc.sendSignal(sig)
+}
+
 func (p *ProjectRunner) StopProcesses(names []string) (map[string]string, error) {
 	stopped := make(map[string]string)
 	successes := 0

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -147,6 +147,10 @@ func (p *PcClient) StopProcess(name string) error {
 	return p.stopProcess(name)
 }
 
+func (p *PcClient) SendSignal(name string, sig int) error {
+	return p.sendSignal(name, sig)
+}
+
 func (p *PcClient) StopProcesses(names []string) (map[string]string, error) {
 	return p.stopProcesses(names)
 }

--- a/src/client/stop.go
+++ b/src/client/stop.go
@@ -32,6 +32,29 @@ func (p *PcClient) stopProcess(name string) error {
 	return errors.New(respErr.Error)
 }
 
+func (p *PcClient) sendSignal(name string, sig int) error {
+	url := fmt.Sprintf("http://%s/process/signal/%s/%d", p.address, name, sig)
+	req, err := http.NewRequest(http.MethodPatch, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	var respErr pcError
+	if err = json.NewDecoder(resp.Body).Decode(&respErr); err != nil {
+		log.Error().Msgf("failed to decode send signal %s response: %v", name, err)
+		return err
+	}
+	return errors.New(respErr.Error)
+}
+
 func (p *PcClient) stopProcesses(names []string) (map[string]string, error) {
 	url := fmt.Sprintf("http://%s/processes/stop", p.address)
 	jsonPayload, err := json.Marshal(names)

--- a/src/command/command_wrapper.go
+++ b/src/command/command_wrapper.go
@@ -67,3 +67,7 @@ func (c *CmdWrapper) Output() ([]byte, error) {
 func (c *CmdWrapper) CombinedOutput() ([]byte, error) {
 	return c.cmd.CombinedOutput()
 }
+
+func (c *CmdWrapper) Signal(sig int, parentOnly bool) error {
+	return c.Stop(sig, parentOnly)
+}

--- a/src/command/command_wrapper_pty.go
+++ b/src/command/command_wrapper_pty.go
@@ -64,6 +64,10 @@ func (c *CmdWrapperPty) Stop(sig int, parentOnly bool) error {
 	return err
 }
 
+func (c *CmdWrapperPty) Signal(sig int, parentOnly bool) error {
+	return c.CmdWrapper.Signal(sig, parentOnly)
+}
+
 func (c *CmdWrapperPty) StdoutPipe() (io.ReadCloser, error) {
 	if c.ptmx == nil {
 		err := c.Start()

--- a/src/command/commander.go
+++ b/src/command/commander.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Commander interface {
+	Signal(sig int, parentOnly bool) error
 	Stop(sig int, _parentOnly bool) error
 	SetCmdArgs()
 	Start() error

--- a/src/command/mock_command.go
+++ b/src/command/mock_command.go
@@ -28,7 +28,12 @@ func (c *MockCommand) Start() error {
 	go c.infoNoiseMaker.Run(ctx)
 	return nil
 }
-func (c *MockCommand) Stop(_ int) error {
+
+func (c *MockCommand) Signal(_ int, _ bool) error {
+	return nil
+}
+
+func (c *MockCommand) Stop(_ int, _ bool) error {
 	c.stopChan <- struct{}{}
 	c.cancel()
 	return nil

--- a/src/tui/actions.go
+++ b/src/tui/actions.go
@@ -23,6 +23,7 @@ const (
 	ActionProcessStart     = ActionName("process_start")
 	ActionProcessScale     = ActionName("process_scale")
 	ActionProcessInfo      = ActionName("process_info")
+	ActionProcessSignal    = ActionName("process_signal")
 	ActionProcessStop      = ActionName("process_stop")
 	ActionProcessRestart   = ActionName("process_restart")
 	ActionProcessScreen    = ActionName("process_screen")
@@ -56,6 +57,7 @@ var defaultShortcuts = map[ActionName]tcell.Key{
 	ActionLogSelection:     tcell.KeyCtrlS,
 	ActionProcessScale:     tcell.KeyF2,
 	ActionProcessInfo:      tcell.KeyF3,
+	ActionProcessSignal:    tcell.KeyF12,
 	ActionProcessStart:     tcell.KeyF7,
 	ActionProcessStop:      tcell.KeyF9,
 	ActionProcessRestart:   tcell.KeyCtrlR,
@@ -112,6 +114,7 @@ var procActionsOrder = []ActionName{
 	ActionProcFilter,
 	ActionProcessScale,
 	ActionProcessInfo,
+	ActionProcessSignal,
 	ActionProcessStart,
 	ActionProcessScreen,
 	ActionProcessStop,
@@ -340,6 +343,9 @@ func newShortCuts() *ShortCuts {
 			},
 			ActionProcessInfo: {
 				Description: "Info",
+			},
+			ActionProcessSignal: {
+				Description: "Signal",
 			},
 			ActionProcessStart: {
 				Description: "Start",

--- a/src/tui/process_signal_dialog.go
+++ b/src/tui/process_signal_dialog.go
@@ -1,0 +1,72 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rivo/tview"
+	"github.com/rs/zerolog/log"
+)
+
+type processSignalOption struct {
+	Signal      int
+	Name        string
+	Description string
+}
+
+func (pv *pcView) showSignalDialog() {
+	options := availableSignalOptions()
+	if len(options) == 0 {
+		pv.showError("Sending signals from the TUI is not supported on this platform")
+		return
+	}
+
+	name := pv.getSelectedProcName()
+	form := tview.NewForm()
+	form.SetCancelFunc(func() {
+		pv.pages.RemovePage(PageDialog)
+	})
+	form.SetItemPadding(1)
+	form.SetBorder(true)
+	form.SetButtonsAlign(tview.AlignCenter)
+	form.SetTitle("Send Signal to " + name)
+
+	labels := make([]string, len(options))
+	current := 0
+	for i, option := range options {
+		labels[i] = fmt.Sprintf("%s (%d) - %s", option.Name, option.Signal, option.Description)
+		if option.Name == "SIGTERM" {
+			current = i
+		}
+	}
+
+	form.AddDropDown("Signal:", labels, current, nil)
+	form.AddButton("Send", func() {
+		selected, _ := form.GetFormItem(0).(*tview.DropDown).GetCurrentOption()
+		if selected < 0 || selected >= len(options) {
+			pv.showError("Please select a signal")
+			return
+		}
+		pv.pages.RemovePage(PageDialog)
+		go pv.handleProcessSignaled(name, options[selected])
+	})
+	form.AddButton("Cancel", func() {
+		pv.pages.RemovePage(PageDialog)
+	})
+
+	pv.styleForm(form)
+	pv.showDialog(form, 76, 10)
+}
+
+func (pv *pcView) handleProcessSignaled(name string, option processSignalOption) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go pv.showAttentionMessage(ctx, fmt.Sprintf("Sending %s to %s", option.Name, name), time.Second, false)
+	pv.showAutoProgress(ctx, time.Second)
+	err := pv.project.SendSignal(name, option.Signal)
+	cancel()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to send signal")
+		pv.showError(err.Error())
+	}
+}

--- a/src/tui/process_signal_options_unix.go
+++ b/src/tui/process_signal_options_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package tui
+
+import "syscall"
+
+func availableSignalOptions() []processSignalOption {
+	return []processSignalOption{
+		{Signal: int(syscall.SIGHUP), Name: "SIGHUP", Description: "hang up or reload"},
+		{Signal: int(syscall.SIGINT), Name: "SIGINT", Description: "interrupt"},
+		{Signal: int(syscall.SIGQUIT), Name: "SIGQUIT", Description: "quit and dump core"},
+		{Signal: int(syscall.SIGUSR1), Name: "SIGUSR1", Description: "application-defined signal 1"},
+		{Signal: int(syscall.SIGUSR2), Name: "SIGUSR2", Description: "application-defined signal 2"},
+		{Signal: int(syscall.SIGABRT), Name: "SIGABRT", Description: "abort"},
+		{Signal: int(syscall.SIGALRM), Name: "SIGALRM", Description: "alarm timer"},
+		{Signal: int(syscall.SIGTERM), Name: "SIGTERM", Description: "terminate"},
+		{Signal: int(syscall.SIGKILL), Name: "SIGKILL", Description: "force kill"},
+		{Signal: int(syscall.SIGCONT), Name: "SIGCONT", Description: "continue"},
+		{Signal: int(syscall.SIGSTOP), Name: "SIGSTOP", Description: "stop execution"},
+		{Signal: int(syscall.SIGTSTP), Name: "SIGTSTP", Description: "terminal stop"},
+	}
+}

--- a/src/tui/process_signal_options_unix_test.go
+++ b/src/tui/process_signal_options_unix_test.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package tui
+
+import "testing"
+
+func TestAvailableSignalOptionsIncludeCommonSignals(t *testing.T) {
+	options := availableSignalOptions()
+	found := map[string]bool{}
+	for _, option := range options {
+		found[option.Name] = true
+	}
+
+	for _, signalName := range []string{"SIGTERM", "SIGKILL", "SIGALRM"} {
+		if !found[signalName] {
+			t.Fatalf("expected %s to be available in the signal picker", signalName)
+		}
+	}
+}

--- a/src/tui/process_signal_options_windows.go
+++ b/src/tui/process_signal_options_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package tui
+
+func availableSignalOptions() []processSignalOption {
+	return nil
+}

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -233,6 +233,7 @@ func (pv *pcView) setShortCutsActions() {
 	})
 	pv.shortcuts.setAction(ActionProcessScale, pv.showScale)
 	pv.shortcuts.setAction(ActionProcessInfo, pv.showInfo)
+	pv.shortcuts.setAction(ActionProcessSignal, pv.showSignalDialog)
 	pv.shortcuts.setAction(ActionLogFind, pv.showSearch)
 	pv.shortcuts.setAction(ActionLogFindNext, func() {
 		pv.logsText.SearchNext()


### PR DESCRIPTION
Thanks for process compose, it's a nice lil' tool!

I'm using [snooze](https://man.voidlinux.org/snooze.1) to schedule commands, and I wanted to be able to send a `SIGALRM` signal via process compose to manually trigger a scheduled task.

I didn't see any such functionality or discussion in issues / PRs, so I had a go at supervising Codex, which generated this code.

I'm not very familiar with Go, but I gave it a read and it seems reasonable.

I ran go fmt, but that changed a ton of unrelated files, which suggests to me that I don't have it configured properly and/or this project doesn't use it, so I skipped that.

I built on MacOS via the nix shell and verified that that the TUI functions as expected in terms of sending signals to processes.

I ran `make ci` and the tests seem to all pass, but I get an error that seems to be related to Nix.

Please let me know if there's anything else I should run.

Feel free to edit this commit or reject the feature outright if you feel like it's not in scope for this project.

Have a great day!

```
(nix:nix-shell-env) cake:process-compose dev$ make ci
go mod download
CGO_ENABLED=0 go build -o bin/process-compose -ldflags="-X github.com/f1bonacc1/process-compose/src/config.Version=v1.90.0 -X github.com/f1bonacc1/process-compose/src/config.CheckForUpdates=true -X github.com/f1bonacc1/process-compose/src/config.Commit=b9f9388 -X github.com/f1bonacc1/process-compose/src/config.Date=2026-03-16T19:46:36Z -X 'github.com/f1bonacc1/process-compose/src/config.ProjectName=Process Compose 🔥' -X 'github.com/f1bonacc1/process-compose/src/config.RemoteProjectName=Process Compose ⚡' -s -w" ./
go test -race ./...
?       github.com/f1bonacc1/process-compose    [no test files]
ok      github.com/f1bonacc1/process-compose/src/admitter       (cached)
ok      github.com/f1bonacc1/process-compose/src/api    (cached)
ok      github.com/f1bonacc1/process-compose/src/app    (cached)
?       github.com/f1bonacc1/process-compose/src/client [no test files]
ok      github.com/f1bonacc1/process-compose/src/cmd    (cached)
?       github.com/f1bonacc1/process-compose/src/command        [no test files]
?       github.com/f1bonacc1/process-compose/src/config [no test files]
?       github.com/f1bonacc1/process-compose/src/docs   [no test files]
ok      github.com/f1bonacc1/process-compose/src/health (cached)
ok      github.com/f1bonacc1/process-compose/src/loader (cached)
ok      github.com/f1bonacc1/process-compose/src/mcp    (cached)
ok      github.com/f1bonacc1/process-compose/src/pclog  (cached)
?       github.com/f1bonacc1/process-compose/src/recipe [no test files]
ok      github.com/f1bonacc1/process-compose/src/scheduler      (cached)
ok      github.com/f1bonacc1/process-compose/src/templater      (cached)
ok      github.com/f1bonacc1/process-compose/src/tui    (cached)
ok      github.com/f1bonacc1/process-compose/src/types  (cached)
?       github.com/f1bonacc1/process-compose/src/updater        [no test files]
ok      github.com/f1bonacc1/process-compose/src/util   (cached)
test -s /Users/dev/software/process-compose/bin/golangci-lint || \
GOBIN=/Users/dev/software/process-compose/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
./bin/golangci-lint run --show-stats -c .golangci.yaml
0 issues.
nix build .
error: flake 'git+file:///Users/dev/software/process-compose' does not provide attribute 'packages.aarch64-darwin.default'
make: *** [Makefile:40: build-nix] Error 1
```
