### PR TITLE
feat: add 'process-compose analyze critical-chain' subcommand

### DIFF
--- a/src/app/process.go
+++ b/src/app/process.go
@@ -141,9 +141,20 @@ loop:
 			return 1
 		}
 
-		p.setStartTime(time.Now())
+		now := time.Now()
+		p.setStartTime(now)
 		p.stateMtx.Lock()
 		p.procState.Pid = p.command.Pid()
+		if p.procState.ProcessStartTime == nil {
+			startCopy := now
+			p.procState.ProcessStartTime = &startCopy
+			// Processes without any readiness signal are considered ready as
+			// soon as they start. Probes/log-ready handlers override this later.
+			if p.readyProber == nil && p.procConf.ReadyLogLine == "" {
+				readyCopy := now
+				p.procState.ProcessReadyTime = &readyCopy
+			}
+		}
 		p.metricsProc, err = puproc.NewProcess(int32(p.procState.Pid))
 		if err != nil {
 			log.Err(err).Msgf("Could not find pid %d with name %s", p.procState.Pid, p.getName())
@@ -549,6 +560,13 @@ func (p *Process) onProcessEnd(state string) {
 	p.setState(state)
 	p.updateProcState()
 
+	p.stateMtx.Lock()
+	if p.procState.ProcessEndTime == nil {
+		now := time.Now()
+		p.procState.ProcessEndTime = &now
+	}
+	p.stateMtx.Unlock()
+
 	p.Lock()
 	p.done = true
 	p.Unlock()
@@ -730,6 +748,10 @@ func (p *Process) handleOutput(pipe io.ReadCloser, output string, handler func(m
 		}
 		if p.procConf.ReadyLogLine != "" && p.procState.Health == types.ProcessHealthUnknown && strings.Contains(line, p.procConf.ReadyLogLine) {
 			p.procState.Health = types.ProcessHealthReady
+			if p.procState.ProcessReadyTime == nil {
+				now := time.Now()
+				p.procState.ProcessReadyTime = &now
+			}
 			p.cancelReadyLogFunc(nil)
 		}
 		p.checkElevatedProcOutput(line)
@@ -1063,6 +1085,10 @@ func (p *Process) setProcHealth(health string) {
 	p.stateMtx.Lock()
 	defer p.stateMtx.Unlock()
 	p.procState.Health = health
+	if health == types.ProcessHealthReady && p.procState.ProcessReadyTime == nil {
+		now := time.Now()
+		p.procState.ProcessReadyTime = &now
+	}
 }
 
 // set elevated process password

--- a/src/app/process.go
+++ b/src/app/process.go
@@ -747,11 +747,9 @@ func (p *Process) handleOutput(pipe io.ReadCloser, output string, handler func(m
 			break
 		}
 		if p.procConf.ReadyLogLine != "" && p.procState.Health == types.ProcessHealthUnknown && strings.Contains(line, p.procConf.ReadyLogLine) {
-			p.procState.Health = types.ProcessHealthReady
-			if p.procState.ProcessReadyTime == nil {
-				now := time.Now()
-				p.procState.ProcessReadyTime = &now
-			}
+			// setProcHealth takes stateMtx, updates Health and (for Ready)
+			// records ProcessReadyTime atomically.
+			p.setProcHealth(types.ProcessHealthReady)
 			p.cancelReadyLogFunc(nil)
 		}
 		p.checkElevatedProcOutput(line)

--- a/src/app/process_timing_test.go
+++ b/src/app/process_timing_test.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+)
+
+// newBareProcessForTimingTests builds the minimum Process needed to exercise
+// the timing-tracking paths (setProcHealth, onProcessEnd bookkeeping) in
+// isolation -- i.e. without actually spawning a child or starting probes.
+func newBareProcessForTimingTests() *Process {
+	return &Process{
+		procConf:  &types.ProcessConfig{Name: "p", ReplicaName: "p"},
+		procState: &types.ProcessState{},
+	}
+}
+
+func TestSetProcHealth_SetsReadyTimeOnce(t *testing.T) {
+	p := newBareProcessForTimingTests()
+
+	before := time.Now()
+	p.setProcHealth(types.ProcessHealthReady)
+	after := time.Now()
+
+	if p.procState.Health != types.ProcessHealthReady {
+		t.Fatalf("Health = %q, want %q", p.procState.Health, types.ProcessHealthReady)
+	}
+	if p.procState.ProcessReadyTime == nil {
+		t.Fatal("ProcessReadyTime was not set")
+	}
+	got := *p.procState.ProcessReadyTime
+	if got.Before(before) || got.After(after) {
+		t.Errorf("ProcessReadyTime = %v, want between %v and %v", got, before, after)
+	}
+
+	// Calling setProcHealth(Ready) again must not overwrite the first timestamp.
+	first := *p.procState.ProcessReadyTime
+	time.Sleep(2 * time.Millisecond)
+	p.setProcHealth(types.ProcessHealthReady)
+	if !p.procState.ProcessReadyTime.Equal(first) {
+		t.Errorf("ProcessReadyTime changed on second Ready call: first=%v second=%v",
+			first, *p.procState.ProcessReadyTime)
+	}
+}
+
+func TestSetProcHealth_NotReadyDoesNotSetTime(t *testing.T) {
+	p := newBareProcessForTimingTests()
+	p.setProcHealth(types.ProcessHealthNotReady)
+	if p.procState.ProcessReadyTime != nil {
+		t.Errorf("ProcessReadyTime unexpectedly set for NotReady: %v",
+			*p.procState.ProcessReadyTime)
+	}
+}
+
+// TestSetProcHealth_ConcurrentReadyNoRace exercises the mutex protection the
+// maintainer asked for. Running under `go test -race` / `make testrace` should
+// flag any unsynchronised access to procState.
+func TestSetProcHealth_ConcurrentReadyNoRace(t *testing.T) {
+	p := newBareProcessForTimingTests()
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			p.setProcHealth(types.ProcessHealthReady)
+		}()
+	}
+	wg.Wait()
+
+	if p.procState.ProcessReadyTime == nil {
+		t.Fatal("ProcessReadyTime not set after concurrent Ready calls")
+	}
+	if p.procState.Health != types.ProcessHealthReady {
+		t.Errorf("Health = %q, want Ready", p.procState.Health)
+	}
+}

--- a/src/cmd/analyze.go
+++ b/src/cmd/analyze.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
-// analyzeCmd represents the analyze command group.
+// analyzeCmd represents the analyze command group. It has no Run of its own;
+// Cobra auto-prints help when a parent command with no Run is invoked without
+// a subcommand.
 var analyzeCmd = &cobra.Command{
 	Use:   "analyze",
 	Short: "Analyze startup timing and dependency information",
@@ -16,12 +16,6 @@ through the dependency graph.
 
 Available subcommands:
   critical-chain    Print the dependency chains ordered by startup time.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			_ = cmd.Help()
-			os.Exit(0)
-		}
-	},
 }
 
 func init() {

--- a/src/cmd/analyze.go
+++ b/src/cmd/analyze.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// analyzeCmd represents the analyze command group.
+var analyzeCmd = &cobra.Command{
+	Use:   "analyze",
+	Short: "Analyze startup timing and dependency information",
+	Long: `Analyze inspects a running process-compose instance to provide insight
+into how long each process took to start up and how those times relate
+through the dependency graph.
+
+Available subcommands:
+  critical-chain    Print the dependency chains ordered by startup time.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			_ = cmd.Help()
+			os.Exit(0)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(analyzeCmd)
+}

--- a/src/cmd/analyze_critical_chain.go
+++ b/src/cmd/analyze_critical_chain.go
@@ -1,0 +1,279 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var analyzeCriticalChainCmd = &cobra.Command{
+	Use:   "critical-chain [process...]",
+	Short: "Print the critical process startup chain",
+	Long: `Print a tree of processes ordered from the processes that nothing
+depends on (top-level) down through their dependencies, annotated with
+startup timings -- similar to 'systemd-analyze critical-chain'.
+
+For each process two times are printed:
+
+  @<offset>   Time after the project started that the process became ready.
+              (For processes without a readiness probe this is the time the
+              process was launched.)
+  +<duration> Time the process spent between launch and becoming ready.
+              Only shown for processes with a readiness signal (readiness
+              probe, liveness probe, or 'ready_log_line').
+
+If process names are given as arguments, only those processes (and their
+dependency sub-chains) are printed; otherwise every top-level process is
+printed.`,
+	Run: runAnalyzeCriticalChain,
+}
+
+func init() {
+	analyzeCmd.AddCommand(analyzeCriticalChainCmd)
+}
+
+func runAnalyzeCriticalChain(cmd *cobra.Command, args []string) {
+	c := getClient()
+
+	projectState, err := c.GetProjectState(false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get project state: %v\n", err)
+		os.Exit(1)
+	}
+
+	procStates, err := c.GetRemoteProcessesState()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get process states: %v\n", err)
+		os.Exit(1)
+	}
+
+	graph, err := c.GetDependencyGraph()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get dependency graph: %v\n", err)
+		os.Exit(1)
+	}
+	graph.RebuildInternalIndices()
+
+	stateByName := make(map[string]*types.ProcessState, len(procStates.States))
+	for i := range procStates.States {
+		s := &procStates.States[i]
+		stateByName[s.Name] = s
+	}
+
+	// Determine the starting set of nodes.
+	var roots []*types.DependencyNode
+	if len(args) > 0 {
+		for _, name := range args {
+			node, ok := graph.AllNodes[name]
+			if !ok {
+				fmt.Fprintf(os.Stderr, "unknown process (or process has no dependencies): %s\n", name)
+				os.Exit(1)
+			}
+			roots = append(roots, node)
+		}
+	} else {
+		// Top-level = processes that nothing depends on. graph.Nodes already
+		// contains the leaves (see BuildDependencyGraph).
+		for _, n := range graph.Nodes {
+			roots = append(roots, n)
+		}
+		// Also include processes from the state that aren't in the graph at
+		// all (isolated) so the user can see their timings too.
+		inGraph := make(map[string]bool, len(graph.AllNodes))
+		for name := range graph.AllNodes {
+			inGraph[name] = true
+		}
+		for _, s := range procStates.States {
+			if !inGraph[s.Name] {
+				roots = append(roots, &types.DependencyNode{Name: s.Name})
+			}
+		}
+	}
+
+	sort.Slice(roots, func(i, j int) bool {
+		ai := readyOffsetForSort(stateByName[roots[i].Name], projectState.StartTime)
+		aj := readyOffsetForSort(stateByName[roots[j].Name], projectState.StartTime)
+		if ai == aj {
+			return roots[i].Name < roots[j].Name
+		}
+		return ai > aj
+	})
+
+	// Header
+	green := color.New(color.FgGreen).SprintFunc()
+	fmt.Println("The time when unit became ready is printed after the \"@\" character.")
+	fmt.Println("The time the unit took to become ready is printed after the \"+\" character.")
+	fmt.Println()
+	fmt.Printf("%s: %s\n", green("Project"), projectState.ProjectName)
+	fmt.Printf("%s: %s\n", green("Started"), projectState.StartTime.Format(time.RFC3339))
+	fmt.Printf("%s: %s\n", green("Up time"), projectState.UpTime.Round(time.Millisecond))
+	fmt.Println()
+
+	for i, root := range roots {
+		last := i == len(roots)-1
+		printCriticalChain(root, stateByName, projectState.StartTime, "", true, last)
+	}
+}
+
+// readyOffsetForSort returns the duration from project start until the process
+// became ready. Processes that never became ready sort to the top (return
+// max duration) so the "slowest" chain is printed first.
+func readyOffsetForSort(s *types.ProcessState, projectStart time.Time) time.Duration {
+	if s == nil {
+		return time.Duration(1<<62 - 1)
+	}
+	if s.ProcessReadyTime != nil {
+		return s.ProcessReadyTime.Sub(projectStart)
+	}
+	if s.ProcessStartTime != nil {
+		return s.ProcessStartTime.Sub(projectStart)
+	}
+	return time.Duration(1<<62 - 1)
+}
+
+func printCriticalChain(
+	node *types.DependencyNode,
+	stateByName map[string]*types.ProcessState,
+	projectStart time.Time,
+	prefix string,
+	isRoot bool,
+	isLast bool,
+) {
+	// Tree branch characters.
+	branch := ""
+	nextPrefix := prefix
+	if !isRoot {
+		if isLast {
+			branch = "└─"
+			nextPrefix = prefix + "  "
+		} else {
+			branch = "├─"
+			nextPrefix = prefix + "│ "
+		}
+	}
+
+	line := formatNodeLine(node, stateByName[node.Name], projectStart)
+	fmt.Printf("%s%s%s\n", prefix, branch, line)
+
+	// Sort dependencies by when they became ready (latest first), mirroring
+	// systemd-analyze critical-chain.
+	deps := make([]*types.DependencyNode, 0, len(node.DependsOn))
+	for _, link := range node.DependsOn {
+		if link.DependencyNode != nil {
+			deps = append(deps, link.DependencyNode)
+		}
+	}
+	sort.Slice(deps, func(i, j int) bool {
+		ai := readyOffsetForSort(stateByName[deps[i].Name], projectStart)
+		aj := readyOffsetForSort(stateByName[deps[j].Name], projectStart)
+		if ai == aj {
+			return deps[i].Name < deps[j].Name
+		}
+		return ai > aj
+	})
+
+	for i, dep := range deps {
+		printCriticalChain(dep, stateByName, projectStart, nextPrefix, false, i == len(deps)-1)
+	}
+}
+
+func formatNodeLine(
+	node *types.DependencyNode,
+	state *types.ProcessState,
+	projectStart time.Time,
+) string {
+	cyan := color.New(color.FgCyan).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+	faint := color.New(color.Faint).SprintFunc()
+
+	name := cyan(node.Name)
+
+	if state == nil {
+		return fmt.Sprintf("%s %s", name, faint("(no state)"))
+	}
+
+	var parts []string
+	parts = append(parts, name)
+
+	if state.ProcessReadyTime != nil {
+		offset := state.ProcessReadyTime.Sub(projectStart)
+		parts = append(parts, fmt.Sprintf("@%s", yellow(formatOffset(offset))))
+	} else if state.ProcessStartTime != nil {
+		offset := state.ProcessStartTime.Sub(projectStart)
+		parts = append(parts,
+			fmt.Sprintf("@%s", yellow(formatOffset(offset))),
+			faint("(not ready)"))
+	} else {
+		parts = append(parts, faint("(not started)"))
+	}
+
+	// +<duration> only meaningful when there is a gap between start and ready.
+	if state.ProcessStartTime != nil && state.ProcessReadyTime != nil {
+		ready := state.ProcessReadyTime.Sub(*state.ProcessStartTime)
+		if ready > 0 {
+			parts = append(parts, fmt.Sprintf("+%s", yellow(formatDuration(ready))))
+		}
+	}
+
+	// Status annotation if anything looks off.
+	switch state.Status {
+	case types.ProcessStateError, types.ProcessStateSkipped:
+		parts = append(parts, red(fmt.Sprintf("[%s]", state.Status)))
+	case types.ProcessStateCompleted, types.ProcessStateRunning:
+		// expected -- no extra annotation
+	default:
+		if state.Status != "" {
+			parts = append(parts, faint(fmt.Sprintf("[%s]", state.Status)))
+		}
+	}
+
+	// Join with spaces.
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += " "
+		}
+		out += p
+	}
+	return out
+}
+
+// formatOffset formats a duration representing "time since project start".
+// Uses a more compact form for shorter durations and a minute-aware form for
+// longer ones, mirroring `systemd-analyze`.
+func formatOffset(d time.Duration) string {
+	if d < 0 {
+		return "?"
+	}
+	if d < time.Minute {
+		return formatDuration(d)
+	}
+	mins := int(d / time.Minute)
+	rem := d - time.Duration(mins)*time.Minute
+	return fmt.Sprintf("%dmin %s", mins, formatDuration(rem))
+}
+
+// formatDuration prints a short human-friendly duration such as "5ms",
+// "1.234s", or "2.500s".
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		return "?"
+	}
+	if d < time.Microsecond {
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	}
+	if d < time.Millisecond {
+		return fmt.Sprintf("%dus", d.Microseconds())
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	secs := float64(d) / float64(time.Second)
+	return fmt.Sprintf("%.3fs", secs)
+}

--- a/src/cmd/analyze_critical_chain.go
+++ b/src/cmd/analyze_critical_chain.go
@@ -2,14 +2,23 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"math"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
+
+// unreadySortOrder is the sort-key returned for processes that never became
+// ready (or have no recorded state). Using the maximum duration means these
+// processes float to the top of the critical-chain listing, mirroring
+// systemd-analyze which puts the slowest/stuck paths first.
+const unreadySortOrder = time.Duration(math.MaxInt64)
 
 var analyzeCriticalChainCmd = &cobra.Command{
 	Use:   "critical-chain [process...]",
@@ -71,8 +80,16 @@ func runAnalyzeCriticalChain(cmd *cobra.Command, args []string) {
 		for _, name := range args {
 			node, ok := graph.AllNodes[name]
 			if !ok {
-				fmt.Fprintf(os.Stderr, "unknown process (or process has no dependencies): %s\n", name)
-				os.Exit(1)
+				// The graph only contains processes that participate in a
+				// dependency edge. If the name refers to an isolated process
+				// that is still known to the project, synthesize a bare node
+				// so its timings are still rendered.
+				if _, exists := stateByName[name]; exists {
+					node = &types.DependencyNode{Name: name}
+				} else {
+					fmt.Fprintf(os.Stderr, "unknown process: %s\n", name)
+					os.Exit(1)
+				}
 			}
 			roots = append(roots, node)
 		}
@@ -95,37 +112,58 @@ func runAnalyzeCriticalChain(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	sort.Slice(roots, func(i, j int) bool {
-		ai := readyOffsetForSort(stateByName[roots[i].Name], projectState.StartTime)
-		aj := readyOffsetForSort(stateByName[roots[j].Name], projectState.StartTime)
-		if ai == aj {
-			return roots[i].Name < roots[j].Name
-		}
-		return ai > aj
-	})
+	renderCriticalChain(os.Stdout, projectState, roots, stateByName)
+}
 
-	// Header
+// renderCriticalChain writes the critical-chain report for the given roots to
+// w. Split out from runAnalyzeCriticalChain so it can be unit-tested without a
+// running server.
+func renderCriticalChain(
+	w io.Writer,
+	projectState *types.ProjectState,
+	roots []*types.DependencyNode,
+	stateByName map[string]*types.ProcessState,
+) {
 	green := color.New(color.FgGreen).SprintFunc()
-	fmt.Println("The time when unit became ready is printed after the \"@\" character.")
-	fmt.Println("The time the unit took to become ready is printed after the \"+\" character.")
-	fmt.Println()
-	fmt.Printf("%s: %s\n", green("Project"), projectState.ProjectName)
-	fmt.Printf("%s: %s\n", green("Started"), projectState.StartTime.Format(time.RFC3339))
-	fmt.Printf("%s: %s\n", green("Up time"), projectState.UpTime.Round(time.Millisecond))
-	fmt.Println()
+	fmt.Fprintln(w, "The time when unit became ready is printed after the \"@\" character.")
+	fmt.Fprintln(w, "The time the unit took to become ready is printed after the \"+\" character.")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "%s: %s\n", green("Project"), projectState.ProjectName)
+	fmt.Fprintf(w, "%s: %s\n", green("Started"), projectState.StartTime.Format(time.RFC3339))
+	fmt.Fprintf(w, "%s: %s\n", green("Up time"), projectState.UpTime.Round(time.Millisecond))
+	fmt.Fprintln(w)
+
+	sortRootsByReadyTime(roots, stateByName, projectState.StartTime)
 
 	for i, root := range roots {
 		last := i == len(roots)-1
-		printCriticalChain(root, stateByName, projectState.StartTime, "", true, last)
+		printCriticalChain(w, root, stateByName, projectState.StartTime, "", true, last)
 	}
 }
 
+// sortRootsByReadyTime sorts nodes in-place by descending ready-time (slowest
+// first); ties are broken by ascending name.
+func sortRootsByReadyTime(
+	nodes []*types.DependencyNode,
+	stateByName map[string]*types.ProcessState,
+	projectStart time.Time,
+) {
+	sort.Slice(nodes, func(i, j int) bool {
+		ai := readyOffsetForSort(stateByName[nodes[i].Name], projectStart)
+		aj := readyOffsetForSort(stateByName[nodes[j].Name], projectStart)
+		if ai == aj {
+			return nodes[i].Name < nodes[j].Name
+		}
+		return ai > aj
+	})
+}
+
 // readyOffsetForSort returns the duration from project start until the process
-// became ready. Processes that never became ready sort to the top (return
-// max duration) so the "slowest" chain is printed first.
+// became ready. Processes that never became ready return unreadySortOrder so
+// the "slowest" / stuck chain is printed first.
 func readyOffsetForSort(s *types.ProcessState, projectStart time.Time) time.Duration {
 	if s == nil {
-		return time.Duration(1<<62 - 1)
+		return unreadySortOrder
 	}
 	if s.ProcessReadyTime != nil {
 		return s.ProcessReadyTime.Sub(projectStart)
@@ -133,10 +171,11 @@ func readyOffsetForSort(s *types.ProcessState, projectStart time.Time) time.Dura
 	if s.ProcessStartTime != nil {
 		return s.ProcessStartTime.Sub(projectStart)
 	}
-	return time.Duration(1<<62 - 1)
+	return unreadySortOrder
 }
 
 func printCriticalChain(
+	w io.Writer,
 	node *types.DependencyNode,
 	stateByName map[string]*types.ProcessState,
 	projectStart time.Time,
@@ -158,7 +197,7 @@ func printCriticalChain(
 	}
 
 	line := formatNodeLine(node, stateByName[node.Name], projectStart)
-	fmt.Printf("%s%s%s\n", prefix, branch, line)
+	fmt.Fprintf(w, "%s%s%s\n", prefix, branch, line)
 
 	// Sort dependencies by when they became ready (latest first), mirroring
 	// systemd-analyze critical-chain.
@@ -168,17 +207,10 @@ func printCriticalChain(
 			deps = append(deps, link.DependencyNode)
 		}
 	}
-	sort.Slice(deps, func(i, j int) bool {
-		ai := readyOffsetForSort(stateByName[deps[i].Name], projectStart)
-		aj := readyOffsetForSort(stateByName[deps[j].Name], projectStart)
-		if ai == aj {
-			return deps[i].Name < deps[j].Name
-		}
-		return ai > aj
-	})
+	sortRootsByReadyTime(deps, stateByName, projectStart)
 
 	for i, dep := range deps {
-		printCriticalChain(dep, stateByName, projectStart, nextPrefix, false, i == len(deps)-1)
+		printCriticalChain(w, dep, stateByName, projectStart, nextPrefix, false, i == len(deps)-1)
 	}
 }
 
@@ -233,15 +265,7 @@ func formatNodeLine(
 		}
 	}
 
-	// Join with spaces.
-	out := ""
-	for i, p := range parts {
-		if i > 0 {
-			out += " "
-		}
-		out += p
-	}
-	return out
+	return strings.Join(parts, " ")
 }
 
 // formatOffset formats a duration representing "time since project start".

--- a/src/cmd/analyze_critical_chain_test.go
+++ b/src/cmd/analyze_critical_chain_test.go
@@ -1,0 +1,371 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+	"github.com/fatih/color"
+)
+
+// disableColor turns off ANSI color escapes so that the test can make exact
+// string comparisons against the output of the renderer.
+func disableColor(t *testing.T) {
+	t.Helper()
+	prev := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = prev })
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"negative", -time.Second, "?"},
+		{"sub-microsecond", 500 * time.Nanosecond, "500ns"},
+		{"sub-millisecond", 500 * time.Microsecond, "500us"},
+		{"sub-second", 234 * time.Millisecond, "234ms"},
+		{"single-second", time.Second, "1.000s"},
+		{"seconds-fractional", 1*time.Second + 234*time.Millisecond, "1.234s"},
+		{"many-seconds", 2500 * time.Millisecond, "2.500s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatDuration(tt.in); got != tt.want {
+				t.Errorf("formatDuration(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"negative", -time.Millisecond, "?"},
+		{"sub-minute", 900 * time.Millisecond, "900ms"},
+		{"exactly-one-minute", time.Minute, "1min 0ns"},
+		{"one-minute-plus", time.Minute + 250*time.Millisecond, "1min 250ms"},
+		{"multi-minute", 4*time.Minute + 30*time.Second + 148*time.Millisecond, "4min 30.148s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatOffset(tt.in); got != tt.want {
+				t.Errorf("formatOffset(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadyOffsetForSort(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ready := start.Add(3 * time.Second)
+	launched := start.Add(1 * time.Second)
+
+	tests := []struct {
+		name string
+		s    *types.ProcessState
+		want time.Duration
+	}{
+		{"nil-state", nil, unreadySortOrder},
+		{"ready-wins-over-start", &types.ProcessState{ProcessReadyTime: &ready, ProcessStartTime: &launched}, 3 * time.Second},
+		{"start-only", &types.ProcessState{ProcessStartTime: &launched}, 1 * time.Second},
+		{"neither", &types.ProcessState{}, unreadySortOrder},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readyOffsetForSort(tt.s, start); got != tt.want {
+				t.Errorf("readyOffsetForSort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatNodeLine(t *testing.T) {
+	disableColor(t)
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	startedAt := start.Add(500 * time.Millisecond)
+	readyAt := start.Add(1500 * time.Millisecond)
+
+	tests := []struct {
+		name  string
+		node  *types.DependencyNode
+		state *types.ProcessState
+		want  string
+	}{
+		{
+			name:  "nil-state",
+			node:  &types.DependencyNode{Name: "orphan"},
+			state: nil,
+			want:  "orphan (no state)",
+		},
+		{
+			name: "ready-with-probe-gap",
+			node: &types.DependencyNode{Name: "postgres"},
+			state: &types.ProcessState{
+				Status:           types.ProcessStateRunning,
+				ProcessStartTime: &startedAt,
+				ProcessReadyTime: &readyAt,
+			},
+			want: "postgres @1.500s +1.000s",
+		},
+		{
+			name: "ready-no-gap", // no readiness probe -- ready == start
+			node: &types.DependencyNode{Name: "bare"},
+			state: &types.ProcessState{
+				Status:           types.ProcessStateRunning,
+				ProcessStartTime: &startedAt,
+				ProcessReadyTime: &startedAt,
+			},
+			want: "bare @500ms",
+		},
+		{
+			name: "launched-but-not-ready",
+			node: &types.DependencyNode{Name: "stuck"},
+			state: &types.ProcessState{
+				Status:           types.ProcessStateRunning,
+				ProcessStartTime: &startedAt,
+			},
+			want: "stuck @500ms (not ready)",
+		},
+		{
+			name:  "never-started-pending",
+			node:  &types.DependencyNode{Name: "pend"},
+			state: &types.ProcessState{Status: types.ProcessStatePending},
+			want:  "pend (not started) [Pending]",
+		},
+		{
+			name:  "error-status",
+			node:  &types.DependencyNode{Name: "err"},
+			state: &types.ProcessState{Status: types.ProcessStateError},
+			want:  "err (not started) [Error]",
+		},
+		{
+			name:  "skipped-status",
+			node:  &types.DependencyNode{Name: "skip"},
+			state: &types.ProcessState{Status: types.ProcessStateSkipped},
+			want:  "skip (not started) [Skipped]",
+		},
+		{
+			name: "completed-no-annotation",
+			node: &types.DependencyNode{Name: "done"},
+			state: &types.ProcessState{
+				Status:           types.ProcessStateCompleted,
+				ProcessStartTime: &startedAt,
+				ProcessReadyTime: &startedAt,
+			},
+			want: "done @500ms",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatNodeLine(tt.node, tt.state, start)
+			if got != tt.want {
+				t.Errorf("formatNodeLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortRootsByReadyTime(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mkReady := func(d time.Duration) *types.ProcessState {
+		t := start.Add(d)
+		return &types.ProcessState{ProcessReadyTime: &t, ProcessStartTime: &t}
+	}
+
+	stateByName := map[string]*types.ProcessState{
+		"fast":    mkReady(100 * time.Millisecond),
+		"slow":    mkReady(5 * time.Second),
+		"medium":  mkReady(1 * time.Second),
+		"unready": {}, // no times -> sorts to top
+		// "tiebreak-b" and "tiebreak-a" share identical ready-time; alphabetical wins.
+		"tiebreak-b": mkReady(2 * time.Second),
+		"tiebreak-a": mkReady(2 * time.Second),
+	}
+
+	nodes := []*types.DependencyNode{
+		{Name: "fast"},
+		{Name: "slow"},
+		{Name: "medium"},
+		{Name: "unready"},
+		{Name: "tiebreak-b"},
+		{Name: "tiebreak-a"},
+	}
+
+	sortRootsByReadyTime(nodes, stateByName, start)
+
+	got := make([]string, len(nodes))
+	for i, n := range nodes {
+		got[i] = n.Name
+	}
+	want := []string{"unready", "slow", "tiebreak-a", "tiebreak-b", "medium", "fast"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("sortRootsByReadyTime() order = %v, want %v", got, want)
+	}
+}
+
+func TestRenderCriticalChainTree(t *testing.T) {
+	disableColor(t)
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mkReady := func(d time.Duration) *types.ProcessState {
+		t := start.Add(d)
+		return &types.ProcessState{
+			Status:           types.ProcessStateCompleted,
+			ProcessStartTime: &t,
+			ProcessReadyTime: &t,
+		}
+	}
+	mkReadyWithGap := func(launchOffset, readyOffset time.Duration) *types.ProcessState {
+		launch := start.Add(launchOffset)
+		ready := start.Add(readyOffset)
+		return &types.ProcessState{
+			Status:           types.ProcessStateRunning,
+			ProcessStartTime: &launch,
+			ProcessReadyTime: &ready,
+		}
+	}
+
+	// Graph:
+	//   app -> db, cache
+	//   web -> app
+	// Only leaves (processes nothing depends on) are roots: "web".
+	dbNode := &types.DependencyNode{Name: "db"}
+	cacheNode := &types.DependencyNode{Name: "cache"}
+	appNode := &types.DependencyNode{
+		Name: "app",
+		DependsOn: map[string]types.DependencyLink{
+			"db":    {DependencyNode: dbNode, Type: "healthy"},
+			"cache": {DependencyNode: cacheNode, Type: "healthy"},
+		},
+	}
+	webNode := &types.DependencyNode{
+		Name: "web",
+		DependsOn: map[string]types.DependencyLink{
+			"app": {DependencyNode: appNode, Type: "healthy"},
+		},
+	}
+
+	stateByName := map[string]*types.ProcessState{
+		"web":   mkReadyWithGap(400*time.Millisecond, 5*time.Second),
+		"app":   mkReadyWithGap(200*time.Millisecond, 3*time.Second),
+		"db":    mkReady(2 * time.Second),   // slower -> first dep of app
+		"cache": mkReady(500 * time.Millisecond),
+	}
+
+	projectState := &types.ProjectState{
+		ProjectName: "test-project",
+		StartTime:   start,
+		UpTime:      10 * time.Second,
+	}
+
+	var buf bytes.Buffer
+	renderCriticalChain(&buf, projectState, []*types.DependencyNode{webNode}, stateByName)
+	out := buf.String()
+
+	// Header assertions.
+	if !strings.Contains(out, "Project: test-project") {
+		t.Errorf("header missing project name:\n%s", out)
+	}
+	if !strings.Contains(out, "Up time: 10s") {
+		t.Errorf("header missing up time:\n%s", out)
+	}
+
+	// Core tree assertions: web -> app -> (db before cache).
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+
+	// Find the tree lines (after the header blank line).
+	treeStart := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, "web ") {
+			treeStart = i
+			break
+		}
+	}
+	if treeStart < 0 {
+		t.Fatalf("couldn't locate web root line in output:\n%s", out)
+	}
+
+	got := lines[treeStart:]
+	want := []string{
+		"web @5.000s +4.600s",
+		"└─app @3.000s +2.800s",
+		"  ├─db @2.000s",
+		"  └─cache @500ms",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("tree line count = %d, want %d\nfull output:\n%s", len(got), len(want), out)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("tree line %d:\n  got:  %q\n  want: %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestRenderCriticalChainSortsSiblingsSlowestFirst(t *testing.T) {
+	disableColor(t)
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mk := func(d time.Duration) *types.ProcessState {
+		t := start.Add(d)
+		return &types.ProcessState{
+			Status:           types.ProcessStateCompleted,
+			ProcessStartTime: &t,
+			ProcessReadyTime: &t,
+		}
+	}
+	a := &types.DependencyNode{Name: "a"}
+	b := &types.DependencyNode{Name: "b"}
+	c := &types.DependencyNode{Name: "c"}
+	parent := &types.DependencyNode{
+		Name: "parent",
+		DependsOn: map[string]types.DependencyLink{
+			"a": {DependencyNode: a},
+			"b": {DependencyNode: b},
+			"c": {DependencyNode: c},
+		},
+	}
+
+	stateByName := map[string]*types.ProcessState{
+		"parent": mk(4 * time.Second),
+		"a":      mk(1 * time.Second),
+		"b":      mk(3 * time.Second),
+		"c":      mk(2 * time.Second),
+	}
+
+	var buf bytes.Buffer
+	renderCriticalChain(&buf, &types.ProjectState{
+		ProjectName: "p",
+		StartTime:   start,
+		UpTime:      5 * time.Second,
+	}, []*types.DependencyNode{parent}, stateByName)
+
+	// Expected sibling order: b (3s) > c (2s) > a (1s). Using descending ready time.
+	depLines := []string{}
+	for _, l := range strings.Split(buf.String(), "\n") {
+		// tree lines rendered for direct children use "├─" or "└─".
+		if strings.HasPrefix(l, "├─") || strings.HasPrefix(l, "└─") {
+			depLines = append(depLines, l)
+		}
+	}
+	want := []string{
+		"├─b @3.000s",
+		"├─c @2.000s",
+		"└─a @1.000s",
+	}
+	if strings.Join(depLines, "\n") != strings.Join(want, "\n") {
+		t.Errorf("sibling order = %v, want %v", depLines, want)
+	}
+}

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -249,6 +249,17 @@ type ProcessState struct {
 	CPU              float64       `json:"cpu"`
 	IsRunning        bool          `json:"is_running"`
 	NextRunTime      *time.Time    `json:"next_run_time,omitempty"`
+	// ProcessStartTime is the wall-clock time the process (first) entered a
+	// running/launched state. Used by `process-compose analyze critical-chain`.
+	ProcessStartTime *time.Time `json:"process_start_time,omitempty"`
+	// ProcessReadyTime is the wall-clock time the process became ready. For
+	// processes with a readiness probe or a `ready_log_line`, this is set when
+	// the probe succeeds / the line is observed. For processes without any
+	// readiness probe, it equals ProcessStartTime.
+	ProcessReadyTime *time.Time `json:"process_ready_time,omitempty"`
+	// ProcessEndTime is the wall-clock time the process ended (completed,
+	// errored, terminated, or was skipped).
+	ProcessEndTime *time.Time `json:"process_end_time,omitempty"`
 }
 
 type ProcessPorts struct {


### PR DESCRIPTION
Note this code was generated with AI assistance.

## Summary

Adds a new top-level `analyze` command, with a first subcommand
`analyze critical-chain`, inspired by `systemd-analyze critical-chain`.
It prints a tree of processes from the ones nothing depends on, down
through their dependencies, annotated with startup timings.

For each process two times are shown:

- `@<offset>` — time after the project started that the process became ready
  (or was launched, for processes with no readiness signal).
- `+<duration>` — time the process spent between launch and becoming ready.
  Only shown for processes with a readiness probe / liveness probe /
  `ready_log_line`.

### Example

```
$ process-compose analyze critical-chain

The time when unit became ready is printed after the "@" character.
The time the unit took to become ready is printed after the "+" character.

Project: example/compose
Started: 2026-04-18T09:01:20-07:00
Up time: 4m48.517s

app (not started) [Pending]
├─migrations (not started) [Pending]
│ ├─postgres @4min 30.148s +270.145s
│ └─setup @4ms (not ready)
├─postgres @4min 30.148s +270.145s
├─redis @2min 10.446s +130.435s
└─setup @4ms (not ready)
...
```

You can also restrict the output to a specific process (and its sub-chain):

```
$ process-compose analyze critical-chain app
```

## What changed

- **`src/types/process.go`**: three optional `*time.Time` fields on
  `ProcessState` (`process_start_time`, `process_ready_time`,
  `process_end_time`). All are `omitempty`, so the JSON wire format is
  backward-compatible for existing clients.
- **`src/app/process.go`**: populates the new timestamps at existing
  lifecycle hook points:
  - `run()` — sets `ProcessStartTime`. For processes with no readiness
    signal (no readiness probe and no `ready_log_line`) this is also used
    as `ProcessReadyTime`.
  - `setProcHealth(Ready)` — sets `ProcessReadyTime` when a readiness
    probe succeeds.
  - `handleOutput()` — sets `ProcessReadyTime` when `ready_log_line`
    matches.
  - `onProcessEnd()` — sets `ProcessEndTime`.
- **`src/cmd/analyze.go`** — new parent `analyze` Cobra command.
- **`src/cmd/analyze_critical_chain.go`** — `critical-chain [process...]`
  subcommand. Implemented purely on the client side: composes the
  existing `/project/state`, `/processes`, and `/graph` endpoints, walks
  the dependency graph, and sorts siblings by descending ready-time
  (same order `systemd-analyze` uses). **No new API endpoints.**

## Motivation

When a process-compose project has many processes with deep dependency
chains, it can be hard to see *which* process is the startup bottleneck.
`process list` shows status and age, but doesn't show how long each
process took to reach the state that unblocks its dependents, and
doesn't walk the dependency graph.

`analyze critical-chain` answers the question "what was the slow path?"
at a glance.

## Test plan

- Built locally with `go build -v -o process-compose .` on Go 1.26.
- `go vet ./...` clean.
- Ran against a real project with many processes and a mixture of
  readiness-probe / `ready_log_line` / no-probe processes; confirmed:
  - Top-level processes are those nothing depends on.
  - Siblings sort by descending ready-time (slowest first), matching
    `systemd-analyze`.
  - `@` and `+` values match the expected wall-clock deltas.
  - Processes that never became ready are annotated `(not ready)` /
    `(not started)` and don't crash the output.
  - `[Skipped]`, `[Error]`, `[Restarting]`, `[Launching]`, etc. status
    annotations are surfaced.
  - Passing explicit process names restricts the tree to those
    sub-chains.
  - Tested with a read-only unix-socket client as well as TCP.

## Backward compatibility

- JSON additions are all `omitempty` pointers, so existing API consumers
  see no difference.
- No existing commands or flags were changed.
- No new API endpoints are introduced.

## Open questions

Happy to iterate on any of these:

- Naming: `analyze critical-chain` mirrors `systemd-analyze`. Open to
  `analyze chain`, `analyze timing`, etc. if preferred.
- Color output: currently uses `fatih/color` like other commands
  (`state`, `list`). Can add a `--no-color` flag / respect `NO_COLOR` if
  desired.
- Output format: currently text-only. A `-o json` mode would be a
  straightforward follow-up if there's interest.