### PR TITLE
feat: add Control MCP server for introspecting process-compose itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ PC_DEBUG_MODE=1 ./bin/process-compose -e .env
 | `client/` | HTTP client for remote API communication |
 | `health/` | Liveness/readiness probe implementations (HTTP, exec) |
 | `scheduler/` | Cron/interval-based process scheduling via `gocron/v2` |
-| `mcp/` | Model Context Protocol server, tools, and resources |
+| `mcp/` | MCP server that wraps user-defined processes as MCP tools/resources |
+| `mcpctl/` | Control MCP server — exposes tools for agents to introspect and control process-compose itself (list/get/start/stop/restart, logs, dep graph); independent from `mcp/` |
 | `pclog/` | Process log buffers with rotation and ANSI color tracking |
 | `command/` | Shell command execution abstraction (cross-platform, PTY support) |
 | `admitter/` | Namespace-based process filtering |

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/f1bonacc1/process-compose/src/config"
 	"github.com/f1bonacc1/process-compose/src/loader"
 	"github.com/f1bonacc1/process-compose/src/mcp"
+	"github.com/f1bonacc1/process-compose/src/mcpctl"
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/f1bonacc1/process-compose/src/updater"
 	"github.com/rs/zerolog"
@@ -251,6 +252,16 @@ func waitForProjectAndServer(useLogger bool, runner *app.ProjectRunner, project 
 		*pcFlags.KeepProjectOn = true
 	}
 
+	// Create and start Control MCP server if enabled. Independent from the
+	// process-wrapping MCP above; runs on its own port with its own lifecycle.
+	mcpCtlManager := mcpctl.NewManager(runner, project.MCPCtlServer, project.Processes)
+	if err := mcpCtlManager.Start(); err != nil {
+		return err
+	}
+	if mcpCtlManager != nil {
+		*pcFlags.KeepProjectOn = true
+	}
+
 	server, err := startHttpServerIfEnabled(useLogger, runner)
 	if err != nil {
 		return err
@@ -263,6 +274,9 @@ func waitForProjectAndServer(useLogger bool, runner *app.ProjectRunner, project 
 	// Stop MCP server
 	if err := mcpManager.Stop(); err != nil {
 		log.Error().Err(err).Msg("Failed to stop MCP server")
+	}
+	if err := mcpCtlManager.Stop(); err != nil {
+		log.Error().Err(err).Msg("Failed to stop Control MCP server")
 	}
 
 	if server != nil {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -247,7 +247,8 @@ func waitForProjectAndServer(useLogger bool, runner *app.ProjectRunner, project 
 		return err
 	}
 
-	// Keep project running if MCP server is active, so we don't exit if all processes are disabled/MCP
+	// Keep project running if either MCP server is active so we don't exit
+	// when all processes are disabled/MCP-wrapped.
 	if mcpManager != nil {
 		*pcFlags.KeepProjectOn = true
 	}
@@ -256,6 +257,10 @@ func waitForProjectAndServer(useLogger bool, runner *app.ProjectRunner, project 
 	// process-wrapping MCP above; runs on its own port with its own lifecycle.
 	mcpCtlManager := mcpctl.NewManager(runner, project.MCPCtlServer, project.Processes)
 	if err := mcpCtlManager.Start(); err != nil {
+		// Unwind the already-started mcp server so we don't leak it.
+		if stopErr := mcpManager.Stop(); stopErr != nil {
+			log.Error().Err(stopErr).Msg("Failed to stop MCP server during mcpctl startup error")
+		}
 		return err
 	}
 	if mcpCtlManager != nil {

--- a/src/loader/validators.go
+++ b/src/loader/validators.go
@@ -210,6 +210,16 @@ func validateMCPConfig(p *types.Project) error {
 		}
 	}
 
+	// Validate Control MCP server configuration
+	if p.MCPCtlServer != nil {
+		if err := p.MCPCtlServer.Validate(); err != nil {
+			if p.IsStrict {
+				return err
+			}
+			log.Error().Err(err).Msg("Control MCP server configuration invalid")
+		}
+	}
+
 	// Validate MCP process configurations
 	for name, proc := range p.Processes {
 		if proc.IsMCP() {

--- a/src/mcpctl/bm25.go
+++ b/src/mcpctl/bm25.go
@@ -1,0 +1,166 @@
+package mcpctl
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// Default Okapi BM25 parameters. These match the `okapibm25` TS reference used
+// by the prior prototype in repl-it-web PR #74337.
+const (
+	DefaultK1 = 1.5
+	DefaultB  = 0.75
+)
+
+// Hit is a single scored document result from a BM25 search.
+type Hit struct {
+	DocID int
+	Score float64
+}
+
+// Corpus holds pre-tokenized documents and the statistics needed to score
+// queries using Okapi BM25.
+type Corpus struct {
+	docs     [][]string       // tokenized docs (one slice per doc)
+	docLens  []int            // doc length per doc
+	avgDL    float64          // average doc length across the corpus
+	docFreq  map[string]int   // term -> number of docs containing term
+	idfCache map[string]float64
+	termFreq []map[string]int // per-doc term frequency
+	k1       float64
+	b        float64
+}
+
+// NewCorpus builds a scoring corpus over the provided tokenized documents.
+// Pass k1 and b as 0 to use the Okapi defaults (1.5 and 0.75 respectively).
+func NewCorpus(docs [][]string, k1, b float64) *Corpus {
+	if k1 <= 0 {
+		k1 = DefaultK1
+	}
+	if b <= 0 {
+		b = DefaultB
+	}
+
+	c := &Corpus{
+		docs:     docs,
+		docLens:  make([]int, len(docs)),
+		docFreq:  make(map[string]int),
+		idfCache: make(map[string]float64),
+		termFreq: make([]map[string]int, len(docs)),
+		k1:       k1,
+		b:        b,
+	}
+
+	var totalLen int
+	for i, tokens := range docs {
+		c.docLens[i] = len(tokens)
+		totalLen += len(tokens)
+
+		tf := make(map[string]int, len(tokens))
+		for _, t := range tokens {
+			tf[t]++
+		}
+		c.termFreq[i] = tf
+
+		for term := range tf {
+			c.docFreq[term]++
+		}
+	}
+	if len(docs) > 0 {
+		c.avgDL = float64(totalLen) / float64(len(docs))
+	}
+	return c
+}
+
+// idf returns the inverse document frequency for a term.
+// Uses the classic Okapi form: log(1 + (N - n + 0.5) / (n + 0.5)).
+func (c *Corpus) idf(term string) float64 {
+	if v, ok := c.idfCache[term]; ok {
+		return v
+	}
+	n := c.docFreq[term]
+	N := len(c.docs)
+	idf := math.Log(1 + (float64(N-n)+0.5)/(float64(n)+0.5))
+	c.idfCache[term] = idf
+	return idf
+}
+
+// Score returns a BM25 score for the query against every document in the corpus.
+// Result[i] is the score for doc i. An empty corpus returns nil; an empty query
+// returns a zero slice.
+func (c *Corpus) Score(query []string) []float64 {
+	if len(c.docs) == 0 {
+		return nil
+	}
+	scores := make([]float64, len(c.docs))
+	if len(query) == 0 {
+		return scores
+	}
+	for _, term := range query {
+		idf := c.idf(term)
+		if idf == 0 {
+			continue
+		}
+		for i, tf := range c.termFreq {
+			f := float64(tf[term])
+			if f == 0 {
+				continue
+			}
+			dl := float64(c.docLens[i])
+			num := f * (c.k1 + 1)
+			den := f + c.k1*(1-c.b+c.b*dl/c.avgDL)
+			scores[i] += idf * num / den
+		}
+	}
+	return scores
+}
+
+// TopN returns the top-n highest-scoring documents for the query, sorted by
+// score descending. Documents with a zero or negative score are omitted.
+// Ties break by lower DocID for deterministic ordering.
+func (c *Corpus) TopN(query []string, n int) []Hit {
+	scores := c.Score(query)
+	hits := make([]Hit, 0, len(scores))
+	for i, s := range scores {
+		if s > 0 {
+			hits = append(hits, Hit{DocID: i, Score: s})
+		}
+	}
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		return hits[i].DocID < hits[j].DocID
+	})
+	if n > 0 && len(hits) > n {
+		hits = hits[:n]
+	}
+	return hits
+}
+
+// Tokenize lowercases the string, splits on whitespace, and strips non-alphanumeric
+// characters. Empty tokens are discarded. Sufficient for log-line search.
+func Tokenize(s string) []string {
+	fields := strings.Fields(strings.ToLower(s))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		clean := stripNonAlnum(f)
+		if clean != "" {
+			out = append(out, clean)
+		}
+	}
+	return out
+}
+
+func stripNonAlnum(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/src/mcpctl/bm25.go
+++ b/src/mcpctl/bm25.go
@@ -7,8 +7,7 @@ import (
 	"unicode"
 )
 
-// Default Okapi BM25 parameters. These match the `okapibm25` TS reference used
-// by the prior prototype in repl-it-web PR #74337.
+// Default Okapi BM25 parameters.
 const (
 	DefaultK1 = 1.5
 	DefaultB  = 0.75

--- a/src/mcpctl/bm25.go
+++ b/src/mcpctl/bm25.go
@@ -1,5 +1,15 @@
 package mcpctl
 
+// Hand-rolled Okapi BM25 for search_logs.
+//
+// The Go ecosystem does not have a lightweight, actively maintained BM25
+// package. The closest options are either (a) full-text search engines like
+// blevesearch/bleve, which pull in a large dependency tree we don't need for
+// ranking a few thousand log lines, or (b) small single-maintainer forks with
+// little usage or upkeep. Given BM25 itself is ~100 lines of standard formula,
+// implementing it here keeps go.mod clean and avoids taking on a dependency
+// we'd have to vet and track.
+
 import (
 	"math"
 	"sort"

--- a/src/mcpctl/bm25_test.go
+++ b/src/mcpctl/bm25_test.go
@@ -1,0 +1,105 @@
+package mcpctl
+
+import (
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"Hello, World!", []string{"hello", "world"}},
+		{"ERROR: failed to connect", []string{"error", "failed", "to", "connect"}},
+		{"   ", nil},
+		{"", nil},
+		{"foo-bar_baz", []string{"foobarbaz"}},
+	}
+	for _, tc := range cases {
+		got := Tokenize(tc.in)
+		if len(got) == 0 && len(tc.want) == 0 {
+			continue
+		}
+		if len(got) != len(tc.want) {
+			t.Fatalf("Tokenize(%q) len = %d, want %d (got %v)", tc.in, len(got), len(tc.want), got)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("Tokenize(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestScoreRanksRelevantDocHigher(t *testing.T) {
+	docs := [][]string{
+		Tokenize("hello world"),
+		Tokenize("error: failed to connect to database"),
+		Tokenize("info: application started"),
+		Tokenize("error handling is important"),
+	}
+	c := NewCorpus(docs, 0, 0)
+
+	hits := c.TopN(Tokenize("error failed"), 10)
+	if len(hits) == 0 {
+		t.Fatalf("expected at least one hit")
+	}
+	if hits[0].DocID != 1 {
+		t.Fatalf("expected doc 1 (error: failed to connect) first, got doc %d with hits %+v", hits[0].DocID, hits)
+	}
+}
+
+func TestScoreEmptyQuery(t *testing.T) {
+	docs := [][]string{
+		Tokenize("alpha beta"),
+		Tokenize("gamma delta"),
+	}
+	c := NewCorpus(docs, 0, 0)
+	scores := c.Score(nil)
+	if len(scores) != len(docs) {
+		t.Fatalf("Score(nil) len = %d, want %d", len(scores), len(docs))
+	}
+	for i, s := range scores {
+		if s != 0 {
+			t.Fatalf("Score(nil)[%d] = %v, want 0", i, s)
+		}
+	}
+}
+
+func TestScoreEmptyCorpus(t *testing.T) {
+	c := NewCorpus(nil, 0, 0)
+	if got := c.Score(Tokenize("anything")); got != nil {
+		t.Fatalf("Score on empty corpus = %v, want nil", got)
+	}
+	if got := c.TopN(Tokenize("anything"), 5); len(got) != 0 {
+		t.Fatalf("TopN on empty corpus = %v, want empty", got)
+	}
+}
+
+func TestTopNCapsResultsAndTieBreaks(t *testing.T) {
+	// Two identical docs produce identical scores; tie-break must be deterministic.
+	docs := [][]string{
+		Tokenize("error error error"),
+		Tokenize("error error error"),
+		Tokenize("nothing here"),
+	}
+	c := NewCorpus(docs, 0, 0)
+	hits := c.TopN(Tokenize("error"), 2)
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(hits))
+	}
+	if hits[0].DocID != 0 || hits[1].DocID != 1 {
+		t.Fatalf("tie-break not stable: got %+v", hits)
+	}
+}
+
+func TestQueryWithNoMatchesReturnsNoHits(t *testing.T) {
+	docs := [][]string{
+		Tokenize("alpha beta"),
+		Tokenize("gamma delta"),
+	}
+	c := NewCorpus(docs, 0, 0)
+	if got := c.TopN(Tokenize("zeta"), 5); len(got) != 0 {
+		t.Fatalf("expected no hits, got %v", got)
+	}
+}

--- a/src/mcpctl/bm25_test.go
+++ b/src/mcpctl/bm25_test.go
@@ -78,10 +78,11 @@ func TestScoreEmptyCorpus(t *testing.T) {
 
 func TestTopNCapsResultsAndTieBreaks(t *testing.T) {
 	// Two identical docs produce identical scores; tie-break must be deterministic.
+	// Build token slices directly to avoid the dupword linter flagging the test source.
 	docs := [][]string{
-		Tokenize("error error error"),
-		Tokenize("error error error"),
-		Tokenize("nothing here"),
+		{"error", "error", "error"},
+		{"error", "error", "error"},
+		{"nothing", "here"},
 	}
 	c := NewCorpus(docs, 0, 0)
 	hits := c.TopN(Tokenize("error"), 2)

--- a/src/mcpctl/manager.go
+++ b/src/mcpctl/manager.go
@@ -1,0 +1,59 @@
+package mcpctl
+
+import (
+	"io"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+	"github.com/rs/zerolog/log"
+)
+
+// Manager handles the Control MCP server lifecycle, mirroring the shape of
+// src/mcp.MCPManager but entirely independent from it.
+type Manager struct {
+	server *Server
+	runner ProcessRunner
+}
+
+// NewManager constructs a Control MCP manager. Returns nil if cfg is nil or
+// not enabled. A nil manager is safe to Start/Stop (no-op).
+func NewManager(runner ProcessRunner, cfg *types.MCPCtlServerConfig, processes types.Processes) *Manager {
+	if cfg == nil || !cfg.IsEnabled() {
+		return nil
+	}
+
+	srv := NewServer(runner, cfg, processes)
+	if srv == nil {
+		return nil
+	}
+
+	log.Info().Msg("Control MCP server initialized")
+
+	return &Manager{
+		server: srv,
+		runner: runner,
+	}
+}
+
+// Start starts the Control MCP server.
+func (m *Manager) Start() error {
+	if m == nil || m.server == nil {
+		return nil
+	}
+	return m.server.Start()
+}
+
+// Stop stops the Control MCP server.
+func (m *Manager) Stop() error {
+	if m == nil || m.server == nil {
+		return nil
+	}
+	return m.server.Stop()
+}
+
+// SetStdio sets stdin/stdout for the stdio transport.
+func (m *Manager) SetStdio(stdin io.Reader, stdout io.Writer) {
+	if m == nil || m.server == nil {
+		return
+	}
+	m.server.SetStdio(stdin, stdout)
+}

--- a/src/mcpctl/manager.go
+++ b/src/mcpctl/manager.go
@@ -7,11 +7,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Manager handles the Control MCP server lifecycle, mirroring the shape of
-// src/mcp.MCPManager but entirely independent from it.
+// Manager handles the Control MCP server lifecycle.
 type Manager struct {
 	server *Server
-	runner ProcessRunner
 }
 
 // NewManager constructs a Control MCP manager. Returns nil if cfg is nil or
@@ -28,10 +26,7 @@ func NewManager(runner ProcessRunner, cfg *types.MCPCtlServerConfig, processes t
 
 	log.Info().Msg("Control MCP server initialized")
 
-	return &Manager{
-		server: srv,
-		runner: runner,
-	}
+	return &Manager{server: srv}
 }
 
 // Start starts the Control MCP server.

--- a/src/mcpctl/manager.go
+++ b/src/mcpctl/manager.go
@@ -1,8 +1,6 @@
 package mcpctl
 
 import (
-	"io"
-
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/rs/zerolog/log"
 )
@@ -43,12 +41,4 @@ func (m *Manager) Stop() error {
 		return nil
 	}
 	return m.server.Stop()
-}
-
-// SetStdio sets stdin/stdout for the stdio transport.
-func (m *Manager) SetStdio(stdin io.Reader, stdout io.Writer) {
-	if m == nil || m.server == nil {
-		return
-	}
-	m.server.SetStdio(stdin, stdout)
 }

--- a/src/mcpctl/server.go
+++ b/src/mcpctl/server.go
@@ -76,9 +76,15 @@ func (s *Server) Start() error {
 	}
 
 	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
-	log.Info().
-		Str("address", addr).
-		Msg("Starting Control MCP server with SSE transport")
+	if !isLoopbackHost(s.config.Host) {
+		log.Warn().
+			Str("address", addr).
+			Msg("Control MCP server is binding to a non-loopback address; it exposes unauthenticated process control")
+	} else {
+		log.Info().
+			Str("address", addr).
+			Msg("Starting Control MCP server with SSE transport")
+	}
 
 	s.sseServer = server.NewSSEServer(s.mcpServer)
 	go func() {
@@ -89,6 +95,15 @@ func (s *Server) Start() error {
 	}()
 
 	return nil
+}
+
+// isLoopbackHost returns true if the bind address is loopback.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
 }
 
 // Stop tears down the server. For SSE, we call sseServer.Shutdown so the

--- a/src/mcpctl/server.go
+++ b/src/mcpctl/server.go
@@ -46,11 +46,18 @@ func NewServer(runner ProcessRunner, cfg *types.MCPCtlServerConfig, processes ty
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// Snapshot the process map so get_dependency_graph can iterate it without
+	// racing any runtime mutation of the project's process set.
+	procSnapshot := make(types.Processes, len(processes))
+	for k, v := range processes {
+		procSnapshot[k] = v
+	}
+
 	s := &Server{
 		mcpServer: server.NewMCPServer("process-compose-mcpctl", "1.0.0"),
 		runner:    runner,
 		config:    cfg,
-		processes: processes,
+		processes: procSnapshot,
 		ctx:       ctx,
 		cancel:    cancel,
 	}

--- a/src/mcpctl/server.go
+++ b/src/mcpctl/server.go
@@ -71,9 +71,6 @@ func (s *Server) Start() error {
 	if s == nil || s.config == nil || !s.config.IsEnabled() {
 		return nil
 	}
-	if !s.config.IsSSE() {
-		return fmt.Errorf("unsupported mcpctl transport: %s", s.config.Transport)
-	}
 
 	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
 	if !isLoopbackHost(s.config.Host) {

--- a/src/mcpctl/server.go
+++ b/src/mcpctl/server.go
@@ -2,10 +2,6 @@
 // tools for AI agents to introspect and control the running process-compose
 // instance itself (list/get/start/stop/restart processes, read logs, search
 // logs, read the dependency graph).
-//
-// This package is deliberately independent from `src/mcp/`. That sibling
-// package wraps user-defined processes as MCP tools — a different concern.
-// The two packages share no Go types, interfaces, or configuration.
 package mcpctl
 
 import (
@@ -13,28 +9,30 @@ import (
 	"fmt"
 	"io"
 	stdLog "log"
+	"time"
 
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog/log"
 )
 
-// ProcessRunner is the subset of ProjectRunner needed by the Control MCP tools.
-// It is defined fresh in this package and duck-typed against *app.ProjectRunner;
-// it does not extend or import the interface from `src/mcp/`.
+// Transport names used in MCPCtlServerConfig.
+const (
+	TransportSSE   = "sse"
+	TransportStdio = "stdio"
+)
+
+// ProcessRunner is the subset of *app.ProjectRunner used by the Control MCP tools.
 type ProcessRunner interface {
 	GetLexicographicProcessNames() ([]string, error)
 	GetProcessesState() (*types.ProcessesState, error)
 	GetProcessState(name string) (*types.ProcessState, error)
-	GetProcessInfo(name string) (*types.ProcessConfig, error)
 	StartProcess(name string) error
 	StopProcess(name string) error
 	RestartProcess(name string) error
 	GetProcessLog(name string, offsetFromEnd, limit int) ([]string, error)
-	GetProcessLogLength(name string) int
 }
 
-// Server is the Control MCP server.
 type Server struct {
 	mcpServer *server.MCPServer
 	runner    ProcessRunner
@@ -42,6 +40,7 @@ type Server struct {
 	processes types.Processes
 	ctx       context.Context
 	cancel    context.CancelFunc
+	sseServer *server.SSEServer
 	stdin     io.Reader
 	stdout    io.Writer
 }
@@ -68,13 +67,13 @@ func NewServer(runner ProcessRunner, cfg *types.MCPCtlServerConfig, processes ty
 	return s
 }
 
-// SetStdio sets the stdin and stdout for the server when using stdio transport.
+// SetStdio sets stdin/stdout for the stdio transport.
 func (s *Server) SetStdio(stdin io.Reader, stdout io.Writer) {
 	s.stdin = stdin
 	s.stdout = stdout
 }
 
-// Start starts the Control MCP server with the configured transport.
+// Start starts the server with the configured transport.
 func (s *Server) Start() error {
 	if s == nil || s.config == nil || !s.config.IsEnabled() {
 		return nil
@@ -90,7 +89,7 @@ func (s *Server) Start() error {
 	if s.config.IsSSE() {
 		return s.startSSE()
 	}
-	return fmt.Errorf("unknown mcpctl transport: %s (only 'sse' and 'stdio' are supported)", s.config.Transport)
+	return fmt.Errorf("unknown mcpctl transport: %s (only %q and %q are supported)", s.config.Transport, TransportSSE, TransportStdio)
 }
 
 func (s *Server) startStdio() error {
@@ -118,9 +117,9 @@ func (s *Server) startSSE() error {
 		Str("address", addr).
 		Msg("Starting Control MCP server with SSE transport")
 
-	sseServer := server.NewSSEServer(s.mcpServer)
+	s.sseServer = server.NewSSEServer(s.mcpServer)
 	go func() {
-		if err := sseServer.Start(addr); err != nil {
+		if err := s.sseServer.Start(addr); err != nil {
 			log.Error().Err(err).Msg("Control MCP SSE server error")
 		}
 	}()
@@ -128,12 +127,20 @@ func (s *Server) startSSE() error {
 	return nil
 }
 
-// Stop cancels the server context.
+// Stop tears down the server. For SSE, we call sseServer.Shutdown so the
+// listener goroutine does not leak.
 func (s *Server) Stop() error {
 	if s == nil {
 		return nil
 	}
 	log.Info().Msg("Stopping Control MCP server")
 	s.cancel()
+	if s.sseServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.sseServer.Shutdown(ctx); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/src/mcpctl/server.go
+++ b/src/mcpctl/server.go
@@ -7,19 +7,11 @@ package mcpctl
 import (
 	"context"
 	"fmt"
-	"io"
-	stdLog "log"
 	"time"
 
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog/log"
-)
-
-// Transport names used in MCPCtlServerConfig.
-const (
-	TransportSSE   = "sse"
-	TransportStdio = "stdio"
 )
 
 // ProcessRunner is the subset of *app.ProjectRunner used by the Control MCP tools.
@@ -41,8 +33,6 @@ type Server struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	sseServer *server.SSEServer
-	stdin     io.Reader
-	stdout    io.Writer
 }
 
 // NewServer constructs a Control MCP server and registers its tools.
@@ -67,51 +57,15 @@ func NewServer(runner ProcessRunner, cfg *types.MCPCtlServerConfig, processes ty
 	return s
 }
 
-// SetStdio sets stdin/stdout for the stdio transport.
-func (s *Server) SetStdio(stdin io.Reader, stdout io.Writer) {
-	s.stdin = stdin
-	s.stdout = stdout
-}
-
-// Start starts the server with the configured transport.
+// Start starts the SSE server.
 func (s *Server) Start() error {
 	if s == nil || s.config == nil || !s.config.IsEnabled() {
 		return nil
 	}
-
-	log.Info().
-		Str("transport", s.config.Transport).
-		Msg("Starting Control MCP server")
-
-	if s.config.IsStdio() {
-		return s.startStdio()
-	}
-	if s.config.IsSSE() {
-		return s.startSSE()
-	}
-	return fmt.Errorf("unknown mcpctl transport: %s (only %q and %q are supported)", s.config.Transport, TransportSSE, TransportStdio)
-}
-
-func (s *Server) startStdio() error {
-	if s.stdin == nil || s.stdout == nil {
-		return fmt.Errorf("mcpctl stdio transport requires stdin and stdout to be set")
+	if !s.config.IsSSE() {
+		return fmt.Errorf("unsupported mcpctl transport: %s", s.config.Transport)
 	}
 
-	log.Info().Msg("Starting Control MCP server with stdio transport")
-
-	stdioServer := server.NewStdioServer(s.mcpServer)
-	stdioServer.SetErrorLogger(stdLog.New(io.Discard, "", 0))
-
-	go func() {
-		if err := stdioServer.Listen(s.ctx, s.stdin, s.stdout); err != nil {
-			log.Error().Err(err).Msg("Control MCP stdio server error")
-		}
-	}()
-
-	return nil
-}
-
-func (s *Server) startSSE() error {
 	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
 	log.Info().
 		Str("address", addr).

--- a/src/mcpctl/server.go
+++ b/src/mcpctl/server.go
@@ -6,7 +6,9 @@ package mcpctl
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/f1bonacc1/process-compose/src/types"
@@ -73,7 +75,8 @@ func (s *Server) Start() error {
 
 	s.sseServer = server.NewSSEServer(s.mcpServer)
 	go func() {
-		if err := s.sseServer.Start(addr); err != nil {
+		err := s.sseServer.Start(addr)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error().Err(err).Msg("Control MCP SSE server error")
 		}
 	}()

--- a/src/mcpctl/server.go
+++ b/src/mcpctl/server.go
@@ -1,0 +1,139 @@
+// Package mcpctl implements the Control MCP server: an MCP server that exposes
+// tools for AI agents to introspect and control the running process-compose
+// instance itself (list/get/start/stop/restart processes, read logs, search
+// logs, read the dependency graph).
+//
+// This package is deliberately independent from `src/mcp/`. That sibling
+// package wraps user-defined processes as MCP tools — a different concern.
+// The two packages share no Go types, interfaces, or configuration.
+package mcpctl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	stdLog "log"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog/log"
+)
+
+// ProcessRunner is the subset of ProjectRunner needed by the Control MCP tools.
+// It is defined fresh in this package and duck-typed against *app.ProjectRunner;
+// it does not extend or import the interface from `src/mcp/`.
+type ProcessRunner interface {
+	GetLexicographicProcessNames() ([]string, error)
+	GetProcessesState() (*types.ProcessesState, error)
+	GetProcessState(name string) (*types.ProcessState, error)
+	GetProcessInfo(name string) (*types.ProcessConfig, error)
+	StartProcess(name string) error
+	StopProcess(name string) error
+	RestartProcess(name string) error
+	GetProcessLog(name string, offsetFromEnd, limit int) ([]string, error)
+	GetProcessLogLength(name string) int
+}
+
+// Server is the Control MCP server.
+type Server struct {
+	mcpServer *server.MCPServer
+	runner    ProcessRunner
+	config    *types.MCPCtlServerConfig
+	processes types.Processes
+	ctx       context.Context
+	cancel    context.CancelFunc
+	stdin     io.Reader
+	stdout    io.Writer
+}
+
+// NewServer constructs a Control MCP server and registers its tools.
+// Returns nil if cfg is nil or not enabled.
+func NewServer(runner ProcessRunner, cfg *types.MCPCtlServerConfig, processes types.Processes) *Server {
+	if cfg == nil || !cfg.IsEnabled() {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := &Server{
+		mcpServer: server.NewMCPServer("process-compose-mcpctl", "1.0.0"),
+		runner:    runner,
+		config:    cfg,
+		processes: processes,
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+
+	s.registerBuiltinTools()
+	return s
+}
+
+// SetStdio sets the stdin and stdout for the server when using stdio transport.
+func (s *Server) SetStdio(stdin io.Reader, stdout io.Writer) {
+	s.stdin = stdin
+	s.stdout = stdout
+}
+
+// Start starts the Control MCP server with the configured transport.
+func (s *Server) Start() error {
+	if s == nil || s.config == nil || !s.config.IsEnabled() {
+		return nil
+	}
+
+	log.Info().
+		Str("transport", s.config.Transport).
+		Msg("Starting Control MCP server")
+
+	if s.config.IsStdio() {
+		return s.startStdio()
+	}
+	if s.config.IsSSE() {
+		return s.startSSE()
+	}
+	return fmt.Errorf("unknown mcpctl transport: %s (only 'sse' and 'stdio' are supported)", s.config.Transport)
+}
+
+func (s *Server) startStdio() error {
+	if s.stdin == nil || s.stdout == nil {
+		return fmt.Errorf("mcpctl stdio transport requires stdin and stdout to be set")
+	}
+
+	log.Info().Msg("Starting Control MCP server with stdio transport")
+
+	stdioServer := server.NewStdioServer(s.mcpServer)
+	stdioServer.SetErrorLogger(stdLog.New(io.Discard, "", 0))
+
+	go func() {
+		if err := stdioServer.Listen(s.ctx, s.stdin, s.stdout); err != nil {
+			log.Error().Err(err).Msg("Control MCP stdio server error")
+		}
+	}()
+
+	return nil
+}
+
+func (s *Server) startSSE() error {
+	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
+	log.Info().
+		Str("address", addr).
+		Msg("Starting Control MCP server with SSE transport")
+
+	sseServer := server.NewSSEServer(s.mcpServer)
+	go func() {
+		if err := sseServer.Start(addr); err != nil {
+			log.Error().Err(err).Msg("Control MCP SSE server error")
+		}
+	}()
+
+	return nil
+}
+
+// Stop cancels the server context.
+func (s *Server) Stop() error {
+	if s == nil {
+		return nil
+	}
+	log.Info().Msg("Stopping Control MCP server")
+	s.cancel()
+	return nil
+}

--- a/src/mcpctl/server_test.go
+++ b/src/mcpctl/server_test.go
@@ -1,0 +1,152 @@
+package mcpctl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// fakeRunner is a minimal ProcessRunner for handler tests.
+type fakeRunner struct {
+	names  []string
+	states map[string]*types.ProcessState
+	logs   map[string][]string
+}
+
+func (f *fakeRunner) GetLexicographicProcessNames() ([]string, error) { return f.names, nil }
+
+func (f *fakeRunner) GetProcessesState() (*types.ProcessesState, error) {
+	states := make([]types.ProcessState, 0, len(f.names))
+	for _, n := range f.names {
+		if st, ok := f.states[n]; ok {
+			states = append(states, *st)
+		}
+	}
+	return &types.ProcessesState{States: states}, nil
+}
+
+func (f *fakeRunner) GetProcessState(name string) (*types.ProcessState, error) {
+	if st, ok := f.states[name]; ok {
+		return st, nil
+	}
+	return nil, fmt.Errorf("process not found: %s", name)
+}
+
+func (f *fakeRunner) StartProcess(string) error   { return nil }
+func (f *fakeRunner) StopProcess(string) error    { return nil }
+func (f *fakeRunner) RestartProcess(string) error { return nil }
+
+func (f *fakeRunner) GetProcessLog(name string, _, limit int) ([]string, error) {
+	lines := f.logs[name]
+	if limit < len(lines) {
+		lines = lines[len(lines)-limit:]
+	}
+	return lines, nil
+}
+
+func TestNewManagerDisabledReturnsNil(t *testing.T) {
+	if m := NewManager(&fakeRunner{}, nil, nil); m != nil {
+		t.Errorf("nil config: expected nil manager, got %v", m)
+	}
+	if m := NewManager(&fakeRunner{}, &types.MCPCtlServerConfig{}, nil); m != nil {
+		t.Errorf("empty config: expected nil manager, got %v", m)
+	}
+	// Nil manager must be safe to Start/Stop.
+	var m *Manager
+	if err := m.Start(); err != nil {
+		t.Errorf("nil Manager.Start = %v, want nil", err)
+	}
+	if err := m.Stop(); err != nil {
+		t.Errorf("nil Manager.Stop = %v, want nil", err)
+	}
+}
+
+func TestNewManagerEnabledReturnsNonNil(t *testing.T) {
+	cfg := &types.MCPCtlServerConfig{Host: "localhost", Port: 11001}
+	m := NewManager(&fakeRunner{}, cfg, types.Processes{})
+	if m == nil {
+		t.Fatal("expected non-nil manager for enabled config")
+	}
+}
+
+// TestGetDependencyGraphOverlaysLiveState verifies the AllNodes/Nodes aliasing
+// claim in the handler: mutating AllNodes also mutates Nodes (because Nodes
+// holds the same *DependencyNode pointers).
+func TestGetDependencyGraphOverlaysLiveState(t *testing.T) {
+	procs := types.Processes{
+		"a": types.ProcessConfig{Name: "a"},
+		"b": types.ProcessConfig{
+			Name: "b",
+			DependsOn: types.DependsOnConfig{
+				"a": types.ProcessDependency{Condition: types.ProcessConditionStarted},
+			},
+		},
+	}
+	runner := &fakeRunner{
+		names: []string{"a", "b"},
+		states: map[string]*types.ProcessState{
+			"a": {Name: "a", Status: "Running", Health: "Ready"},
+			"b": {Name: "b", Status: "Completed", Health: "-"},
+		},
+	}
+	srv := NewServer(runner, &types.MCPCtlServerConfig{Host: "localhost", Port: 11001}, procs)
+	if srv == nil {
+		t.Fatal("NewServer returned nil")
+	}
+
+	res, err := srv.toolGetDependencyGraph(context.Background(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handler returned error result: %+v", res.Content)
+	}
+
+	var payload struct {
+		Nodes map[string]struct {
+			Name      string `json:"name"`
+			Status    string `json:"process_status"`
+			IsReady   string `json:"is_ready"`
+			DependsOn map[string]struct {
+				Name    string `json:"name"`
+				Status  string `json:"process_status"`
+				IsReady string `json:"is_ready"`
+			} `json:"depends_on"`
+		} `json:"nodes"`
+	}
+	text := extractJSONText(t, res)
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("unmarshal: %v (raw=%s)", err, text)
+	}
+
+	// b is the only leaf; verify its overlay + dep link overlay.
+	b, ok := payload.Nodes["b"]
+	if !ok {
+		t.Fatalf("missing node 'b' in %+v", payload.Nodes)
+	}
+	if b.Status != "Completed" || b.IsReady != "-" {
+		t.Errorf("b overlay wrong: status=%s is_ready=%s", b.Status, b.IsReady)
+	}
+	a, ok := b.DependsOn["a"]
+	if !ok {
+		t.Fatalf("missing depends_on 'a' in %+v", b.DependsOn)
+	}
+	if a.Status != "Running" || a.IsReady != "Ready" {
+		t.Errorf("a overlay wrong via DependsOn: status=%s is_ready=%s", a.Status, a.IsReady)
+	}
+}
+
+func extractJSONText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	for _, c := range res.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			return tc.Text
+		}
+	}
+	t.Fatal("no TextContent in result")
+	return ""
+}

--- a/src/mcpctl/tools.go
+++ b/src/mcpctl/tools.go
@@ -1,0 +1,388 @@
+package mcpctl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/rs/zerolog/log"
+)
+
+// Default limits for log-fetching tools.
+const (
+	defaultGetLogsLines   = 100
+	maxGetLogsLines       = 1000
+	defaultSearchTopK     = 20
+	maxSearchTopK         = 100
+	defaultSearchLogLimit = 500
+	maxSearchLogLimit     = 5000
+)
+
+// registerBuiltinTools registers the 8 Control MCP tools on the server.
+func (s *Server) registerBuiltinTools() {
+	s.mcpServer.AddTool(
+		mcp.NewTool("list_processes",
+			mcp.WithDescription("List all processes managed by process-compose with a summary of their state."),
+		),
+		s.toolListProcesses,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("get_process",
+			mcp.WithDescription("Get detailed status for a single process (status, PID, uptime, CPU, memory, restarts, exit code, namespace, readiness)."),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+		),
+		s.toolGetProcess,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("get_logs",
+			mcp.WithDescription("Return recent log lines for a process."),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+			mcp.WithNumber("lines", mcp.Description(fmt.Sprintf("Number of lines to return from the tail (default %d, cap %d).", defaultGetLogsLines, maxGetLogsLines))),
+			mcp.WithNumber("offset", mcp.Description("Offset from the end of the log buffer (default 0).")),
+		),
+		s.toolGetLogs,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("search_logs",
+			mcp.WithDescription("Search process logs for a query string using BM25 ranking."),
+			mcp.WithString("query", mcp.Required(), mcp.Description("Search query.")),
+			mcp.WithString("name", mcp.Description("Optional process name. If omitted, search across all processes.")),
+			mcp.WithNumber("top_k", mcp.Description(fmt.Sprintf("Number of top results to return (default %d, cap %d).", defaultSearchTopK, maxSearchTopK))),
+			mcp.WithNumber("log_limit", mcp.Description(fmt.Sprintf("Max number of recent log lines to index per process (default %d, cap %d).", defaultSearchLogLimit, maxSearchLogLimit))),
+		),
+		s.toolSearchLogs,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("start_process",
+			mcp.WithDescription("Start a process by name."),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+		),
+		s.toolStartProcess,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("stop_process",
+			mcp.WithDescription("Stop a running process by name."),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+		),
+		s.toolStopProcess,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("restart_process",
+			mcp.WithDescription("Restart a process by name."),
+			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+		),
+		s.toolRestartProcess,
+	)
+
+	s.mcpServer.AddTool(
+		mcp.NewTool("get_dependency_graph",
+			mcp.WithDescription("Return the dependency graph of processes along with their current live status."),
+		),
+		s.toolGetDependencyGraph,
+	)
+
+	log.Info().Int("count", 8).Msg("Registered Control MCP tools")
+}
+
+// --- Tool handlers ---
+
+type processSummary struct {
+	Name      string  `json:"name"`
+	Namespace string  `json:"namespace,omitempty"`
+	Status    string  `json:"status"`
+	IsReady   string  `json:"is_ready"`
+	Pid       int     `json:"pid"`
+	Restarts  int     `json:"restarts"`
+	ExitCode  int     `json:"exit_code"`
+	AgeSec    float64 `json:"age_seconds"`
+}
+
+func (s *Server) toolListProcesses(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	states, err := s.runner.GetProcessesState()
+	if err != nil {
+		return mcp.NewToolResultErrorf("failed to get processes state: %v", err), nil
+	}
+	out := struct {
+		Processes []processSummary `json:"processes"`
+	}{
+		Processes: make([]processSummary, 0, len(states.States)),
+	}
+	for _, st := range states.States {
+		out.Processes = append(out.Processes, processSummary{
+			Name:      st.Name,
+			Namespace: st.Namespace,
+			Status:    st.Status,
+			IsReady:   st.Health,
+			Pid:       st.Pid,
+			Restarts:  st.Restarts,
+			ExitCode:  st.ExitCode,
+			AgeSec:    st.Age.Seconds(),
+		})
+	}
+	return mcp.NewToolResultJSON(out)
+}
+
+type processDetail struct {
+	Name      string  `json:"name"`
+	Namespace string  `json:"namespace,omitempty"`
+	Status    string  `json:"status"`
+	IsReady   string  `json:"is_ready"`
+	Pid       int     `json:"pid"`
+	Restarts  int     `json:"restarts"`
+	ExitCode  int     `json:"exit_code"`
+	AgeSec    float64 `json:"age_seconds"`
+	CPU       float64 `json:"cpu"`
+	Mem       int64   `json:"mem"`
+	IsRunning bool    `json:"is_running"`
+}
+
+func (s *Server) toolGetProcess(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultErrorf("missing 'name': %v", err), nil
+	}
+	st, err := s.runner.GetProcessState(name)
+	if err != nil {
+		return mcp.NewToolResultErrorf("failed to get process state for %q: %v", name, err), nil
+	}
+	return mcp.NewToolResultJSON(processDetail{
+		Name:      st.Name,
+		Namespace: st.Namespace,
+		Status:    st.Status,
+		IsReady:   st.Health,
+		Pid:       st.Pid,
+		Restarts:  st.Restarts,
+		ExitCode:  st.ExitCode,
+		AgeSec:    st.Age.Seconds(),
+		CPU:       st.CPU,
+		Mem:       st.Mem,
+		IsRunning: st.IsRunning,
+	})
+}
+
+func (s *Server) toolGetLogs(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultErrorf("missing 'name': %v", err), nil
+	}
+	lines := req.GetInt("lines", defaultGetLogsLines)
+	if lines <= 0 {
+		lines = defaultGetLogsLines
+	}
+	if lines > maxGetLogsLines {
+		lines = maxGetLogsLines
+	}
+	offset := req.GetInt("offset", 0)
+	if offset < 0 {
+		offset = 0
+	}
+
+	logs, err := s.runner.GetProcessLog(name, offset, lines)
+	if err != nil {
+		return mcp.NewToolResultErrorf("failed to get logs for %q: %v", name, err), nil
+	}
+	return mcp.NewToolResultJSON(struct {
+		Name  string   `json:"name"`
+		Lines []string `json:"lines"`
+	}{Name: name, Lines: logs})
+}
+
+type searchHit struct {
+	Process string  `json:"process"`
+	LineIdx int     `json:"line_idx"`
+	Score   float64 `json:"score"`
+	Text    string  `json:"text"`
+}
+
+func (s *Server) toolSearchLogs(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	query, err := req.RequireString("query")
+	if err != nil {
+		return mcp.NewToolResultErrorf("missing 'query': %v", err), nil
+	}
+	topK := req.GetInt("top_k", defaultSearchTopK)
+	if topK <= 0 {
+		topK = defaultSearchTopK
+	}
+	if topK > maxSearchTopK {
+		topK = maxSearchTopK
+	}
+	logLimit := req.GetInt("log_limit", defaultSearchLogLimit)
+	if logLimit <= 0 {
+		logLimit = defaultSearchLogLimit
+	}
+	if logLimit > maxSearchLogLimit {
+		logLimit = maxSearchLogLimit
+	}
+
+	procNames, err := s.targetProcessNames(req.GetString("name", ""))
+	if err != nil {
+		return mcp.NewToolResultErrorf("%v", err), nil
+	}
+
+	// Gather log lines per process, tracking which doc belongs to which process.
+	var (
+		docs       [][]string
+		lineTexts  []string
+		lineProcs  []string
+		lineIndex  []int
+	)
+	for _, pname := range procNames {
+		lines, err := s.runner.GetProcessLog(pname, 0, logLimit)
+		if err != nil {
+			log.Warn().Err(err).Str("process", pname).Msg("search_logs: skipping process")
+			continue
+		}
+		for i, line := range lines {
+			docs = append(docs, Tokenize(line))
+			lineTexts = append(lineTexts, line)
+			lineProcs = append(lineProcs, pname)
+			lineIndex = append(lineIndex, i)
+		}
+	}
+
+	queryTokens := Tokenize(query)
+	corpus := NewCorpus(docs, 0, 0)
+	hits := corpus.TopN(queryTokens, topK)
+
+	out := struct {
+		Query string      `json:"query"`
+		Hits  []searchHit `json:"hits"`
+	}{
+		Query: query,
+		Hits:  make([]searchHit, 0, len(hits)),
+	}
+	for _, h := range hits {
+		out.Hits = append(out.Hits, searchHit{
+			Process: lineProcs[h.DocID],
+			LineIdx: lineIndex[h.DocID],
+			Score:   h.Score,
+			Text:    lineTexts[h.DocID],
+		})
+	}
+	return mcp.NewToolResultJSON(out)
+}
+
+// targetProcessNames returns a single-element slice if name is set, otherwise
+// all known process names. Returns an error if name is set but unknown.
+func (s *Server) targetProcessNames(name string) ([]string, error) {
+	if name != "" {
+		if _, err := s.runner.GetProcessState(name); err != nil {
+			return nil, fmt.Errorf("unknown process %q: %w", name, err)
+		}
+		return []string{name}, nil
+	}
+	names, err := s.runner.GetLexicographicProcessNames()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list processes: %w", err)
+	}
+	return names, nil
+}
+
+func (s *Server) toolStartProcess(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultErrorf("missing 'name': %v", err), nil
+	}
+	if err := s.runner.StartProcess(name); err != nil {
+		return mcp.NewToolResultErrorf("failed to start %q: %v", name, err), nil
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("started %s", name)), nil
+}
+
+func (s *Server) toolStopProcess(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultErrorf("missing 'name': %v", err), nil
+	}
+	if err := s.runner.StopProcess(name); err != nil {
+		return mcp.NewToolResultErrorf("failed to stop %q: %v", name, err), nil
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("stopped %s", name)), nil
+}
+
+func (s *Server) toolRestartProcess(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("name")
+	if err != nil {
+		return mcp.NewToolResultErrorf("missing 'name': %v", err), nil
+	}
+	if err := s.runner.RestartProcess(name); err != nil {
+		return mcp.NewToolResultErrorf("failed to restart %q: %v", name, err), nil
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("restarted %s", name)), nil
+}
+
+type depLink struct {
+	Name           string             `json:"name"`
+	Status         string             `json:"process_status"`
+	IsReady        string             `json:"is_ready"`
+	DependencyType string             `json:"dependency_type"`
+	DependsOn      map[string]depLink `json:"depends_on,omitempty"`
+}
+
+type depNodeJSON struct {
+	Name      string             `json:"name"`
+	Status    string             `json:"process_status"`
+	IsReady   string             `json:"is_ready"`
+	DependsOn map[string]depLink `json:"depends_on,omitempty"`
+}
+
+func (s *Server) toolGetDependencyGraph(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	graph := types.BuildDependencyGraph(s.processes)
+
+	// Overlay live state onto each node in AllNodes.
+	for name, node := range graph.AllNodes {
+		if st, err := s.runner.GetProcessState(name); err == nil && st != nil {
+			node.Status = st.Status
+			node.IsReady = st.Health
+		}
+	}
+
+	nodes := make(map[string]depNodeJSON, len(graph.Nodes))
+	for name, node := range graph.Nodes {
+		nodes[name] = toDepNodeJSON(node)
+	}
+
+	return mcp.NewToolResultJSON(struct {
+		Nodes map[string]depNodeJSON `json:"nodes"`
+	}{Nodes: nodes})
+}
+
+func toDepNodeJSON(node *types.DependencyNode) depNodeJSON {
+	out := depNodeJSON{
+		Name:    node.Name,
+		Status:  node.Status,
+		IsReady: node.IsReady,
+	}
+	if len(node.DependsOn) > 0 {
+		out.DependsOn = make(map[string]depLink, len(node.DependsOn))
+		for depName, link := range node.DependsOn {
+			out.DependsOn[depName] = toDepLink(link)
+		}
+	}
+	return out
+}
+
+func toDepLink(link types.DependencyLink) depLink {
+	out := depLink{
+		DependencyType: link.Type,
+	}
+	if link.DependencyNode != nil {
+		out.Name = link.Name
+		out.Status = link.Status
+		out.IsReady = link.IsReady
+		if len(link.DependsOn) > 0 {
+			out.DependsOn = make(map[string]depLink, len(link.DependsOn))
+			for depName, sub := range link.DependsOn {
+				out.DependsOn[depName] = toDepLink(sub)
+			}
+		}
+	}
+	return out
+}

--- a/src/mcpctl/tools.go
+++ b/src/mcpctl/tools.go
@@ -19,7 +19,7 @@ const (
 	maxSearchLogLimit     = 5000
 )
 
-// registerBuiltinTools registers the 8 Control MCP tools on the server.
+// registerBuiltinTools registers the Control MCP tools on the server.
 func (s *Server) registerBuiltinTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("list_processes",
@@ -88,7 +88,7 @@ func (s *Server) registerBuiltinTools() {
 		s.toolGetDependencyGraph,
 	)
 
-	log.Info().Int("count", 8).Msg("Registered Control MCP tools")
+	log.Info().Msg("Registered Control MCP tools")
 }
 
 // --- Tool handlers ---
@@ -194,11 +194,15 @@ func (s *Server) toolGetLogs(_ context.Context, req mcp.CallToolRequest) (*mcp.C
 	}{Name: name, Lines: logs})
 }
 
+// searchHit is one result from search_logs. ChunkIdx is the line's 0-based
+// index within the log chunk we searched (tail of log_limit lines per
+// process), not an absolute position in the process's log buffer — lines
+// may roll out between calls.
 type searchHit struct {
-	Process string  `json:"process"`
-	LineIdx int     `json:"line_idx"`
-	Score   float64 `json:"score"`
-	Text    string  `json:"text"`
+	Process  string  `json:"process"`
+	ChunkIdx int     `json:"chunk_idx"`
+	Score    float64 `json:"score"`
+	Text     string  `json:"text"`
 }
 
 func (s *Server) toolSearchLogs(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -228,10 +232,10 @@ func (s *Server) toolSearchLogs(_ context.Context, req mcp.CallToolRequest) (*mc
 
 	// Gather log lines per process, tracking which doc belongs to which process.
 	var (
-		docs       [][]string
-		lineTexts  []string
-		lineProcs  []string
-		lineIndex  []int
+		docs      [][]string
+		lineTexts []string
+		lineProcs []string
+		chunkIdxs []int
 	)
 	for _, pname := range procNames {
 		lines, err := s.runner.GetProcessLog(pname, 0, logLimit)
@@ -243,7 +247,7 @@ func (s *Server) toolSearchLogs(_ context.Context, req mcp.CallToolRequest) (*mc
 			docs = append(docs, Tokenize(line))
 			lineTexts = append(lineTexts, line)
 			lineProcs = append(lineProcs, pname)
-			lineIndex = append(lineIndex, i)
+			chunkIdxs = append(chunkIdxs, i)
 		}
 	}
 
@@ -260,10 +264,10 @@ func (s *Server) toolSearchLogs(_ context.Context, req mcp.CallToolRequest) (*mc
 	}
 	for _, h := range hits {
 		out.Hits = append(out.Hits, searchHit{
-			Process: lineProcs[h.DocID],
-			LineIdx: lineIndex[h.DocID],
-			Score:   h.Score,
-			Text:    lineTexts[h.DocID],
+			Process:  lineProcs[h.DocID],
+			ChunkIdx: chunkIdxs[h.DocID],
+			Score:    h.Score,
+			Text:     lineTexts[h.DocID],
 		})
 	}
 	return mcp.NewToolResultJSON(out)

--- a/src/mcpctl/tools.go
+++ b/src/mcpctl/tools.go
@@ -23,67 +23,72 @@ const (
 func (s *Server) registerBuiltinTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("list_processes",
-			mcp.WithDescription("List all processes managed by process-compose with a summary of their state."),
+			mcp.WithDescription(`List all processes managed by process-compose with their current status, CPU/memory usage, uptime, and restart count. Use this to get an overview of what's running in the local dev environment.`),
 		),
 		s.toolListProcesses,
 	)
 
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_process",
-			mcp.WithDescription("Get detailed status for a single process (status, PID, uptime, CPU, memory, restarts, exit code, namespace, readiness)."),
-			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+			mcp.WithDescription(`Get detailed information about a specific process including its command, dependencies, status, and resource usage.`),
+			mcp.WithString("name", mcp.Required(), mcp.Description(`The process name (e.g. "web-server", "chort")`)),
 		),
 		s.toolGetProcess,
 	)
 
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_logs",
-			mcp.WithDescription("Return recent log lines for a process."),
-			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
-			mcp.WithNumber("lines", mcp.Description(fmt.Sprintf("Number of lines to return from the tail (default %d, cap %d).", defaultGetLogsLines, maxGetLogsLines))),
-			mcp.WithNumber("offset", mcp.Description("Offset from the end of the log buffer (default 0).")),
+			mcp.WithDescription(`Get the most recent log lines from a process (tail). Use this for time-sensitive queries like "what just happened", "latest errors", or "recent output" — it returns only the tail end of the log buffer.`),
+			mcp.WithString("name", mcp.Required(), mcp.Description(`The process name (e.g. "web-server", "chort")`)),
+			mcp.WithNumber("lines", mcp.Description(`Number of recent lines to fetch (default 100, max 1000)`)),
+			mcp.WithNumber("offset", mcp.Description(`Offset from the end of the log buffer (default 0)`)),
 		),
 		s.toolGetLogs,
 	)
 
 	s.mcpServer.AddTool(
 		mcp.NewTool("search_logs",
-			mcp.WithDescription("Search process logs for a query string using BM25 ranking."),
-			mcp.WithString("query", mcp.Required(), mcp.Description("Search query.")),
-			mcp.WithString("name", mcp.Description("Optional process name. If omitted, search across all processes.")),
-			mcp.WithNumber("top_k", mcp.Description(fmt.Sprintf("Number of top results to return (default %d, cap %d).", defaultSearchTopK, maxSearchTopK))),
-			mcp.WithNumber("log_limit", mcp.Description(fmt.Sprintf("Max number of recent log lines to index per process (default %d, cap %d).", defaultSearchLogLimit, maxSearchLogLimit))),
+			mcp.WithDescription(`Search the entire log buffer using BM25 text ranking. Results are ranked by relevance, NOT by time — they may be old or out of chronological order. For recent/latest logs, use get_logs instead.
+
+Examples:
+- Search for errors: query="error failed exception"
+- Search for a specific module: query="GraphQL resolver timeout"
+- Search across all processes: omit the name parameter`),
+			mcp.WithString("query", mcp.Required(), mcp.Description(`Search query (space-separated terms)`)),
+			mcp.WithString("name", mcp.Description(`Process name to search. If omitted, searches all processes.`)),
+			mcp.WithNumber("top_k", mcp.Description(`Number of top results to return (default 20, max 100)`)),
+			mcp.WithNumber("log_limit", mcp.Description(`Max log lines to fetch per process before searching (default 500, max 5000)`)),
 		),
 		s.toolSearchLogs,
 	)
 
 	s.mcpServer.AddTool(
 		mcp.NewTool("start_process",
-			mcp.WithDescription("Start a process by name."),
-			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+			mcp.WithDescription(`Start a stopped process managed by process-compose.`),
+			mcp.WithString("name", mcp.Required(), mcp.Description(`The process name to start`)),
 		),
 		s.toolStartProcess,
 	)
 
 	s.mcpServer.AddTool(
 		mcp.NewTool("stop_process",
-			mcp.WithDescription("Stop a running process by name."),
-			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+			mcp.WithDescription(`Stop a running process managed by process-compose.`),
+			mcp.WithString("name", mcp.Required(), mcp.Description(`The process name to stop`)),
 		),
 		s.toolStopProcess,
 	)
 
 	s.mcpServer.AddTool(
 		mcp.NewTool("restart_process",
-			mcp.WithDescription("Restart a process by name."),
-			mcp.WithString("name", mcp.Required(), mcp.Description("Name of the process.")),
+			mcp.WithDescription(`Restart a process managed by process-compose.`),
+			mcp.WithString("name", mcp.Required(), mcp.Description(`The process name to restart (e.g. "web-server")`)),
 		),
 		s.toolRestartProcess,
 	)
 
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_dependency_graph",
-			mcp.WithDescription("Return the dependency graph of processes along with their current live status."),
+			mcp.WithDescription(`Get the process dependency graph showing which processes depend on which others. Useful for understanding startup order and failure cascading.`),
 		),
 		s.toolGetDependencyGraph,
 	)

--- a/src/mcpctl/tools.go
+++ b/src/mcpctl/tools.go
@@ -318,71 +318,20 @@ func (s *Server) toolRestartProcess(_ context.Context, req mcp.CallToolRequest) 
 	return mcp.NewToolResultText(fmt.Sprintf("restarted %s", name)), nil
 }
 
-type depLink struct {
-	Name           string             `json:"name"`
-	Status         string             `json:"process_status"`
-	IsReady        string             `json:"is_ready"`
-	DependencyType string             `json:"dependency_type"`
-	DependsOn      map[string]depLink `json:"depends_on,omitempty"`
-}
-
-type depNodeJSON struct {
-	Name      string             `json:"name"`
-	Status    string             `json:"process_status"`
-	IsReady   string             `json:"is_ready"`
-	DependsOn map[string]depLink `json:"depends_on,omitempty"`
-}
-
 func (s *Server) toolGetDependencyGraph(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	graph := types.BuildDependencyGraph(s.processes)
 
-	// Overlay live state onto each node in AllNodes.
-	for name, node := range graph.AllNodes {
-		if st, err := s.runner.GetProcessState(name); err == nil && st != nil {
-			node.Status = st.Status
-			node.IsReady = st.Health
-		}
-	}
-
-	nodes := make(map[string]depNodeJSON, len(graph.Nodes))
-	for name, node := range graph.Nodes {
-		nodes[name] = toDepNodeJSON(node)
-	}
-
-	return mcp.NewToolResultJSON(struct {
-		Nodes map[string]depNodeJSON `json:"nodes"`
-	}{Nodes: nodes})
-}
-
-func toDepNodeJSON(node *types.DependencyNode) depNodeJSON {
-	out := depNodeJSON{
-		Name:    node.Name,
-		Status:  node.Status,
-		IsReady: node.IsReady,
-	}
-	if len(node.DependsOn) > 0 {
-		out.DependsOn = make(map[string]depLink, len(node.DependsOn))
-		for depName, link := range node.DependsOn {
-			out.DependsOn[depName] = toDepLink(link)
-		}
-	}
-	return out
-}
-
-func toDepLink(link types.DependencyLink) depLink {
-	out := depLink{
-		DependencyType: link.Type,
-	}
-	if link.DependencyNode != nil {
-		out.Name = link.Name
-		out.Status = link.Status
-		out.IsReady = link.IsReady
-		if len(link.DependsOn) > 0 {
-			out.DependsOn = make(map[string]depLink, len(link.DependsOn))
-			for depName, sub := range link.DependsOn {
-				out.DependsOn[depName] = toDepLink(sub)
+	// Overlay live state in a single pass. graph.Nodes aliases the pointers in
+	// graph.AllNodes, so mutating AllNodes propagates to Nodes automatically.
+	if states, err := s.runner.GetProcessesState(); err == nil {
+		for i := range states.States {
+			st := &states.States[i]
+			if node, ok := graph.AllNodes[st.Name]; ok {
+				node.Status = st.Status
+				node.IsReady = st.Health
 			}
 		}
 	}
-	return out
+
+	return mcp.NewToolResultJSON(graph)
 }

--- a/src/mcpctl/tools.go
+++ b/src/mcpctl/tools.go
@@ -325,15 +325,18 @@ func (s *Server) toolRestartProcess(_ context.Context, req mcp.CallToolRequest) 
 func (s *Server) toolGetDependencyGraph(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	graph := types.BuildDependencyGraph(s.processes)
 
+	states, err := s.runner.GetProcessesState()
+	if err != nil {
+		return mcp.NewToolResultErrorf("failed to get processes state: %v", err), nil
+	}
+
 	// Overlay live state in a single pass. graph.Nodes aliases the pointers in
 	// graph.AllNodes, so mutating AllNodes propagates to Nodes automatically.
-	if states, err := s.runner.GetProcessesState(); err == nil {
-		for i := range states.States {
-			st := &states.States[i]
-			if node, ok := graph.AllNodes[st.Name]; ok {
-				node.Status = st.Status
-				node.IsReady = st.Health
-			}
+	for i := range states.States {
+		st := &states.States[i]
+		if node, ok := graph.AllNodes[st.Name]; ok {
+			node.Status = st.Status
+			node.IsReady = st.Health
 		}
 	}
 

--- a/src/types/mcpctl.go
+++ b/src/types/mcpctl.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+const (
+	mcpCtlTransportSSE   = "sse"
+	mcpCtlTransportStdio = "stdio"
+)
+
 // MCPCtlServerConfig defines the configuration for the Control MCP server,
 // which exposes tools for introspecting and controlling process-compose itself
 // (list/get/start/stop/restart processes, read logs, search logs, dependency graph).
@@ -29,7 +34,7 @@ func (m *MCPCtlServerConfig) IsSSE() bool {
 	if m == nil {
 		return false
 	}
-	return m.Transport == "" || m.Transport == "sse"
+	return m.Transport == "" || m.Transport == mcpCtlTransportSSE
 }
 
 // IsStdio returns true if transport is stdio.
@@ -37,12 +42,12 @@ func (m *MCPCtlServerConfig) IsStdio() bool {
 	if m == nil {
 		return false
 	}
-	return m.getTransport() == "stdio"
+	return m.getTransport() == mcpCtlTransportStdio
 }
 
 func (m *MCPCtlServerConfig) getTransport() string {
 	if m == nil || m.Transport == "" {
-		return "sse"
+		return mcpCtlTransportSSE
 	}
 	return strings.ToLower(m.Transport)
 }
@@ -54,11 +59,11 @@ func (m *MCPCtlServerConfig) Validate() error {
 	}
 
 	transport := m.getTransport()
-	if transport != "sse" && transport != "stdio" {
-		return fmt.Errorf("invalid mcpctl_server transport: %s (must be 'sse' or 'stdio')", m.Transport)
+	if transport != mcpCtlTransportSSE && transport != mcpCtlTransportStdio {
+		return fmt.Errorf("invalid mcpctl_server transport: %s (must be %q or %q)", m.Transport, mcpCtlTransportSSE, mcpCtlTransportStdio)
 	}
 
-	if transport == "stdio" {
+	if transport == mcpCtlTransportStdio {
 		return nil
 	}
 

--- a/src/types/mcpctl.go
+++ b/src/types/mcpctl.go
@@ -1,11 +1,6 @@
 package types
 
-import (
-	"fmt"
-	"strings"
-)
-
-const mcpCtlTransportSSE = "sse"
+import "fmt"
 
 // MCPCtlServerConfig defines the configuration for the Control MCP server,
 // which exposes tools for introspecting and controlling process-compose itself
@@ -13,10 +8,12 @@ const mcpCtlTransportSSE = "sse"
 //
 // This is distinct from MCPServerConfig (mcp_server:), which wraps user-defined
 // processes as MCP tools. The two servers are independent and may run simultaneously.
+//
+// Transport is always SSE. stdio isn't offered because under `up` the TUI or
+// the sibling mcp_server stdio transport already owns the process stdio.
 type MCPCtlServerConfig struct {
-	Host      string `yaml:"host,omitempty"`
-	Port      int    `yaml:"port,omitempty"`
-	Transport string `yaml:"transport,omitempty"` // Optional: defaults to "sse"
+	Host string `yaml:"host,omitempty"`
+	Port int    `yaml:"port,omitempty"`
 }
 
 // IsEnabled returns true if the Control MCP server is configured.
@@ -24,37 +21,19 @@ type MCPCtlServerConfig struct {
 // An empty block (mcpctl_server: {}) is treated as disabled — a user must
 // set at least one field to opt in. Mirrors MCPServerConfig.IsEnabled.
 func (m *MCPCtlServerConfig) IsEnabled() bool {
-	return m != nil && (m.Transport != "" || m.Host != "" || m.Port > 0)
-}
-
-// IsSSE returns true if transport is sse (or default). Only SSE is supported.
-func (m *MCPCtlServerConfig) IsSSE() bool {
-	if m == nil {
-		return false
-	}
-	return m.Transport == "" || strings.ToLower(m.Transport) == mcpCtlTransportSSE
+	return m != nil && (m.Host != "" || m.Port > 0)
 }
 
 // Validate checks if the Control MCP server configuration is valid.
-//
-// Only SSE transport is supported. Under `up`, stdio is already owned by the
-// TUI or the sibling mcp_server stdio transport, so mcpctl over stdio has no
-// practical place to send its traffic.
 func (m *MCPCtlServerConfig) Validate() error {
 	if m == nil {
 		return nil
 	}
-
-	if m.Transport != "" && strings.ToLower(m.Transport) != mcpCtlTransportSSE {
-		return fmt.Errorf("invalid mcpctl_server transport: %s (only %q is supported)", m.Transport, mcpCtlTransportSSE)
-	}
-
 	if m.Host == "" {
 		return fmt.Errorf("mcpctl_server requires host")
 	}
 	if m.Port <= 0 {
 		return fmt.Errorf("mcpctl_server requires a valid port")
 	}
-
 	return nil
 }

--- a/src/types/mcpctl.go
+++ b/src/types/mcpctl.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 	"strings"
-	"time"
 )
 
 const mcpCtlTransportSSE = "sse"
@@ -18,7 +17,6 @@ type MCPCtlServerConfig struct {
 	Host      string `yaml:"host,omitempty"`
 	Port      int    `yaml:"port,omitempty"`
 	Transport string `yaml:"transport,omitempty"` // Optional: defaults to "sse"
-	Timeout   string `yaml:"timeout,omitempty"`   // Optional: defaults to "5m"
 }
 
 // IsEnabled returns true if the Control MCP server is configured.
@@ -59,13 +57,4 @@ func (m *MCPCtlServerConfig) Validate() error {
 	}
 
 	return nil
-}
-
-// GetTimeout returns the timeout duration for the Control MCP server.
-// Returns 0 if not set (caller should use default).
-func (m *MCPCtlServerConfig) GetTimeout() (time.Duration, error) {
-	if m == nil || m.Timeout == "" {
-		return 0, nil
-	}
-	return time.ParseDuration(m.Timeout)
 }

--- a/src/types/mcpctl.go
+++ b/src/types/mcpctl.go
@@ -1,0 +1,82 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MCPCtlServerConfig defines the configuration for the Control MCP server,
+// which exposes tools for introspecting and controlling process-compose itself
+// (list/get/start/stop/restart processes, read logs, search logs, dependency graph).
+//
+// This is distinct from MCPServerConfig (mcp_server:), which wraps user-defined
+// processes as MCP tools. The two servers are independent and may run simultaneously.
+type MCPCtlServerConfig struct {
+	Host      string `yaml:"host,omitempty"`
+	Port      int    `yaml:"port,omitempty"`
+	Transport string `yaml:"transport,omitempty"` // Optional: defaults to "sse"
+	Timeout   string `yaml:"timeout,omitempty"`   // Optional: defaults to "5m"
+}
+
+// IsEnabled returns true if the Control MCP server is configured.
+func (m *MCPCtlServerConfig) IsEnabled() bool {
+	return m != nil && (m.IsStdio() || m.Transport != "" || m.Host != "" || m.Port > 0)
+}
+
+// IsSSE returns true if transport is sse (or default).
+func (m *MCPCtlServerConfig) IsSSE() bool {
+	if m == nil {
+		return false
+	}
+	return m.Transport == "" || m.Transport == "sse"
+}
+
+// IsStdio returns true if transport is stdio.
+func (m *MCPCtlServerConfig) IsStdio() bool {
+	if m == nil {
+		return false
+	}
+	return m.getTransport() == "stdio"
+}
+
+func (m *MCPCtlServerConfig) getTransport() string {
+	if m == nil || m.Transport == "" {
+		return "sse"
+	}
+	return strings.ToLower(m.Transport)
+}
+
+// Validate checks if the Control MCP server configuration is valid.
+func (m *MCPCtlServerConfig) Validate() error {
+	if m == nil {
+		return nil
+	}
+
+	transport := m.getTransport()
+	if transport != "sse" && transport != "stdio" {
+		return fmt.Errorf("invalid mcpctl_server transport: %s (must be 'sse' or 'stdio')", m.Transport)
+	}
+
+	if transport == "stdio" {
+		return nil
+	}
+
+	if m.Host == "" {
+		return fmt.Errorf("mcpctl_server SSE transport requires host")
+	}
+	if m.Port <= 0 {
+		return fmt.Errorf("mcpctl_server SSE transport requires a valid port")
+	}
+
+	return nil
+}
+
+// GetTimeout returns the timeout duration for the Control MCP server.
+// Returns 0 if not set (caller should use default).
+func (m *MCPCtlServerConfig) GetTimeout() (time.Duration, error) {
+	if m == nil || m.Timeout == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(m.Timeout)
+}

--- a/src/types/mcpctl.go
+++ b/src/types/mcpctl.go
@@ -6,10 +6,7 @@ import (
 	"time"
 )
 
-const (
-	mcpCtlTransportSSE   = "sse"
-	mcpCtlTransportStdio = "stdio"
-)
+const mcpCtlTransportSSE = "sse"
 
 // MCPCtlServerConfig defines the configuration for the Control MCP server,
 // which exposes tools for introspecting and controlling process-compose itself
@@ -25,53 +22,40 @@ type MCPCtlServerConfig struct {
 }
 
 // IsEnabled returns true if the Control MCP server is configured.
+//
+// An empty block (mcpctl_server: {}) is treated as disabled — a user must
+// set at least one field to opt in. Mirrors MCPServerConfig.IsEnabled.
 func (m *MCPCtlServerConfig) IsEnabled() bool {
-	return m != nil && (m.IsStdio() || m.Transport != "" || m.Host != "" || m.Port > 0)
+	return m != nil && (m.Transport != "" || m.Host != "" || m.Port > 0)
 }
 
-// IsSSE returns true if transport is sse (or default).
+// IsSSE returns true if transport is sse (or default). Only SSE is supported.
 func (m *MCPCtlServerConfig) IsSSE() bool {
 	if m == nil {
 		return false
 	}
-	return m.Transport == "" || m.Transport == mcpCtlTransportSSE
-}
-
-// IsStdio returns true if transport is stdio.
-func (m *MCPCtlServerConfig) IsStdio() bool {
-	if m == nil {
-		return false
-	}
-	return m.getTransport() == mcpCtlTransportStdio
-}
-
-func (m *MCPCtlServerConfig) getTransport() string {
-	if m == nil || m.Transport == "" {
-		return mcpCtlTransportSSE
-	}
-	return strings.ToLower(m.Transport)
+	return m.Transport == "" || strings.ToLower(m.Transport) == mcpCtlTransportSSE
 }
 
 // Validate checks if the Control MCP server configuration is valid.
+//
+// Only SSE transport is supported. Under `up`, stdio is already owned by the
+// TUI or the sibling mcp_server stdio transport, so mcpctl over stdio has no
+// practical place to send its traffic.
 func (m *MCPCtlServerConfig) Validate() error {
 	if m == nil {
 		return nil
 	}
 
-	transport := m.getTransport()
-	if transport != mcpCtlTransportSSE && transport != mcpCtlTransportStdio {
-		return fmt.Errorf("invalid mcpctl_server transport: %s (must be %q or %q)", m.Transport, mcpCtlTransportSSE, mcpCtlTransportStdio)
-	}
-
-	if transport == mcpCtlTransportStdio {
-		return nil
+	if m.Transport != "" && strings.ToLower(m.Transport) != mcpCtlTransportSSE {
+		return fmt.Errorf("invalid mcpctl_server transport: %s (only %q is supported)", m.Transport, mcpCtlTransportSSE)
 	}
 
 	if m.Host == "" {
-		return fmt.Errorf("mcpctl_server SSE transport requires host")
+		return fmt.Errorf("mcpctl_server requires host")
 	}
 	if m.Port <= 0 {
-		return fmt.Errorf("mcpctl_server SSE transport requires a valid port")
+		return fmt.Errorf("mcpctl_server requires a valid port")
 	}
 
 	return nil

--- a/src/types/mcpctl_test.go
+++ b/src/types/mcpctl_test.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestMCPCtlServerConfigIsEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *MCPCtlServerConfig
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty block", &MCPCtlServerConfig{}, false},
+		{"port only", &MCPCtlServerConfig{Port: 11001}, true},
+		{"host only", &MCPCtlServerConfig{Host: "localhost"}, true},
+		{"transport only", &MCPCtlServerConfig{Transport: "sse"}, true},
+		{"fully populated", &MCPCtlServerConfig{Host: "localhost", Port: 11001, Transport: "sse"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.IsEnabled(); got != tc.want {
+				t.Errorf("IsEnabled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMCPCtlServerConfigValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *MCPCtlServerConfig
+		wantErr bool
+	}{
+		{"nil", nil, false},
+		{"valid sse", &MCPCtlServerConfig{Host: "localhost", Port: 11001, Transport: "sse"}, false},
+		{"sse default transport", &MCPCtlServerConfig{Host: "localhost", Port: 11001}, false},
+		{"uppercase sse accepted", &MCPCtlServerConfig{Host: "localhost", Port: 11001, Transport: "SSE"}, false},
+		{"stdio rejected", &MCPCtlServerConfig{Transport: "stdio", Host: "localhost", Port: 11001}, true},
+		{"unknown transport rejected", &MCPCtlServerConfig{Transport: "websocket", Host: "localhost", Port: 11001}, true},
+		{"missing host", &MCPCtlServerConfig{Port: 11001}, true},
+		{"missing port", &MCPCtlServerConfig{Host: "localhost"}, true},
+		{"zero port", &MCPCtlServerConfig{Host: "localhost", Port: 0, Transport: "sse"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/src/types/mcpctl_test.go
+++ b/src/types/mcpctl_test.go
@@ -1,8 +1,6 @@
 package types
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestMCPCtlServerConfigIsEnabled(t *testing.T) {
 	cases := []struct {
@@ -14,8 +12,7 @@ func TestMCPCtlServerConfigIsEnabled(t *testing.T) {
 		{"empty block", &MCPCtlServerConfig{}, false},
 		{"port only", &MCPCtlServerConfig{Port: 11001}, true},
 		{"host only", &MCPCtlServerConfig{Host: "localhost"}, true},
-		{"transport only", &MCPCtlServerConfig{Transport: "sse"}, true},
-		{"fully populated", &MCPCtlServerConfig{Host: "localhost", Port: 11001, Transport: "sse"}, true},
+		{"fully populated", &MCPCtlServerConfig{Host: "localhost", Port: 11001}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -33,14 +30,10 @@ func TestMCPCtlServerConfigValidate(t *testing.T) {
 		wantErr bool
 	}{
 		{"nil", nil, false},
-		{"valid sse", &MCPCtlServerConfig{Host: "localhost", Port: 11001, Transport: "sse"}, false},
-		{"sse default transport", &MCPCtlServerConfig{Host: "localhost", Port: 11001}, false},
-		{"uppercase sse accepted", &MCPCtlServerConfig{Host: "localhost", Port: 11001, Transport: "SSE"}, false},
-		{"stdio rejected", &MCPCtlServerConfig{Transport: "stdio", Host: "localhost", Port: 11001}, true},
-		{"unknown transport rejected", &MCPCtlServerConfig{Transport: "websocket", Host: "localhost", Port: 11001}, true},
+		{"valid", &MCPCtlServerConfig{Host: "localhost", Port: 11001}, false},
 		{"missing host", &MCPCtlServerConfig{Port: 11001}, true},
 		{"missing port", &MCPCtlServerConfig{Host: "localhost"}, true},
-		{"zero port", &MCPCtlServerConfig{Host: "localhost", Port: 0, Transport: "sse"}, true},
+		{"zero port", &MCPCtlServerConfig{Host: "localhost", Port: 0}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/src/types/project.go
+++ b/src/types/project.go
@@ -32,6 +32,7 @@ type Project struct {
 	DotEnvVars          map[string]string    `yaml:"dot_env_vars,omitempty"`
 	Extensions          map[string]any       `yaml:",inline"`
 	MCPServer           *MCPServerConfig     `yaml:"mcp_server,omitempty"`
+	MCPCtlServer        *MCPCtlServerConfig  `yaml:"mcpctl_server,omitempty"`
 }
 
 type ProcessFunc func(process ProcessConfig) error


### PR DESCRIPTION
## Summary

Adds an optional **Control MCP server** (`src/mcpctl/`) that exposes 8 MCP
tools letting agents introspect and control the running process-compose
instance itself — BM25-ranked log search, list/get processes, tail recent
logs, start/stop/restart processes, and read the dependency graph.

Closes #460.

## Context

This is orthogonal to the existing `src/mcp/` package (which wraps
user-defined processes as MCP tools). Both packages use
`mark3labs/mcp-go` but share no Go types, interfaces, or config — they
run as two independent servers on separate ports and can be enabled
independently.

## Usage

Enable via a new top-level block in the project YAML:

```yaml
mcpctl_server:
  host: localhost
  port: 11001
```

With the above, running `process-compose up` exposes an SSE MCP endpoint
at `http://localhost:11001/sse`. Off by default — an absent or empty
block does nothing.

## Tools

| Tool | Purpose |
|------|---------|
| `search_logs` | BM25-ranked search across one or all processes |
| `list_processes` | Snapshot of all processes + live state |
| `get_process` | Detail for one process |
| `get_logs` | Tail N lines from one process |
| `start_process` / `stop_process` / `restart_process` | Lifecycle |
| `get_dependency_graph` | Dependency graph + live status overlay |

## Design notes

- **Zero new dependencies.** `mark3labs/mcp-go` was already pinned. BM25
  is a ~160-line hand roll (`src/mcpctl/bm25.go`) — there's no lightweight
  maintained BM25 package in the Go ecosystem, and pulling in a full
  search engine like `bleve` for a few thousand log lines felt like too
  much. Rationale is documented at the top of `bm25.go`.
- **Independent package.** No imports of `src/mcp/`;
  `mcpctl.ProcessRunner` is a fresh local interface duck-typed against
  `*app.ProjectRunner`.
- **SSE only.** Under `up`, stdio is already owned by the TUI or the
  sibling `mcp_server` stdio transport, so mcpctl-over-stdio has no place
  to send its traffic.
- **Loopback warning.** The endpoint exposes unauthenticated process
  control (same posture as the existing `mcp_server`). Startup logs a
  prominent warning when bound to a non-loopback address.

## Files

- **New:** `src/mcpctl/{server,manager,tools,bm25}.go` + tests
- **New:** `src/types/mcpctl.go` + tests (`MCPCtlServerConfig`)
- **Modified:** `src/cmd/root.go` (start/stop alongside `mcp` manager,
  unwind cleanly on partial-startup errors),
  `src/loader/validators.go` (validate block),
  `src/types/project.go` (add field),
  `CLAUDE.md` (package table)

## Test plan

- [x] `go test -race ./src/mcpctl/... ./src/types/...` — BM25 ranking,
      `Validate`, `Manager` nil-safety, dep-graph overlay round-trip
- [x] `make lint` clean
- [x] `make build` green
- [x] End-to-end smoke: compose file with two processes +
      `mcpctl_server` block; MCP `initialize`, `tools/list`, and each
      tool call returns correctly shaped JSON-RPC responses over SSE
- [ ] Review for upstream style / naming preferences

## Out of scope (follow-ups)

- Auth on the SSE endpoint (existing `mcp_server` doesn't auth either;
  the loopback warning documents the expectation)
- CLI flag enablement — YAML-only for MVP
- MCP resources for log streams (tools-only for first cut)
- Stemming / fuzzy matching in `search_logs`
