### PR TITLE
Add BM25 search and dependency graph as tools in the MCP server

### DIFF
--- a/src/mcp/bm25.go
+++ b/src/mcp/bm25.go
@@ -1,0 +1,175 @@
+package mcp
+
+// Hand-rolled Okapi BM25 for search_logs.
+//
+// The Go ecosystem does not have a lightweight, actively maintained BM25
+// package. The closest options are either (a) full-text search engines like
+// blevesearch/bleve, which pull in a large dependency tree we don't need for
+// ranking a few thousand log lines, or (b) small single-maintainer forks with
+// little usage or upkeep. Given BM25 itself is ~100 lines of standard formula,
+// implementing it here keeps go.mod clean and avoids taking on a dependency
+// we'd have to vet and track.
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// Default Okapi BM25 parameters.
+const (
+	DefaultK1 = 1.5
+	DefaultB  = 0.75
+)
+
+// Hit is a single scored document result from a BM25 search.
+type Hit struct {
+	DocID int
+	Score float64
+}
+
+// Corpus holds pre-tokenized documents and the statistics needed to score
+// queries using Okapi BM25.
+type Corpus struct {
+	docs     [][]string       // tokenized docs (one slice per doc)
+	docLens  []int            // doc length per doc
+	avgDL    float64          // average doc length across the corpus
+	docFreq  map[string]int   // term -> number of docs containing term
+	idfCache map[string]float64
+	termFreq []map[string]int // per-doc term frequency
+	k1       float64
+	b        float64
+}
+
+// NewCorpus builds a scoring corpus over the provided tokenized documents.
+// Pass k1 and b as 0 to use the Okapi defaults (1.5 and 0.75 respectively).
+func NewCorpus(docs [][]string, k1, b float64) *Corpus {
+	if k1 <= 0 {
+		k1 = DefaultK1
+	}
+	if b <= 0 {
+		b = DefaultB
+	}
+
+	c := &Corpus{
+		docs:     docs,
+		docLens:  make([]int, len(docs)),
+		docFreq:  make(map[string]int),
+		idfCache: make(map[string]float64),
+		termFreq: make([]map[string]int, len(docs)),
+		k1:       k1,
+		b:        b,
+	}
+
+	var totalLen int
+	for i, tokens := range docs {
+		c.docLens[i] = len(tokens)
+		totalLen += len(tokens)
+
+		tf := make(map[string]int, len(tokens))
+		for _, t := range tokens {
+			tf[t]++
+		}
+		c.termFreq[i] = tf
+
+		for term := range tf {
+			c.docFreq[term]++
+		}
+	}
+	if len(docs) > 0 {
+		c.avgDL = float64(totalLen) / float64(len(docs))
+	}
+	return c
+}
+
+// idf returns the inverse document frequency for a term.
+// Uses the classic Okapi form: log(1 + (N - n + 0.5) / (n + 0.5)).
+func (c *Corpus) idf(term string) float64 {
+	if v, ok := c.idfCache[term]; ok {
+		return v
+	}
+	n := c.docFreq[term]
+	N := len(c.docs)
+	idf := math.Log(1 + (float64(N-n)+0.5)/(float64(n)+0.5))
+	c.idfCache[term] = idf
+	return idf
+}
+
+// Score returns a BM25 score for the query against every document in the corpus.
+// Result[i] is the score for doc i. An empty corpus returns nil; an empty query
+// returns a zero slice.
+func (c *Corpus) Score(query []string) []float64 {
+	if len(c.docs) == 0 {
+		return nil
+	}
+	scores := make([]float64, len(c.docs))
+	if len(query) == 0 {
+		return scores
+	}
+	for _, term := range query {
+		idf := c.idf(term)
+		if idf == 0 {
+			continue
+		}
+		for i, tf := range c.termFreq {
+			f := float64(tf[term])
+			if f == 0 {
+				continue
+			}
+			dl := float64(c.docLens[i])
+			num := f * (c.k1 + 1)
+			den := f + c.k1*(1-c.b+c.b*dl/c.avgDL)
+			scores[i] += idf * num / den
+		}
+	}
+	return scores
+}
+
+// TopN returns the top-n highest-scoring documents for the query, sorted by
+// score descending. Documents with a zero or negative score are omitted.
+// Ties break by lower DocID for deterministic ordering.
+func (c *Corpus) TopN(query []string, n int) []Hit {
+	scores := c.Score(query)
+	hits := make([]Hit, 0, len(scores))
+	for i, s := range scores {
+		if s > 0 {
+			hits = append(hits, Hit{DocID: i, Score: s})
+		}
+	}
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		return hits[i].DocID < hits[j].DocID
+	})
+	if n > 0 && len(hits) > n {
+		hits = hits[:n]
+	}
+	return hits
+}
+
+// Tokenize lowercases the string, splits on whitespace, and strips non-alphanumeric
+// characters. Empty tokens are discarded. Sufficient for log-line search.
+func Tokenize(s string) []string {
+	fields := strings.Fields(strings.ToLower(s))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		clean := stripNonAlnum(f)
+		if clean != "" {
+			out = append(out, clean)
+		}
+	}
+	return out
+}
+
+func stripNonAlnum(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/src/mcp/bm25.go
+++ b/src/mcp/bm25.go
@@ -149,27 +149,15 @@ func (c *Corpus) TopN(query []string, n int) []Hit {
 	return hits
 }
 
-// Tokenize lowercases the string, splits on whitespace, and strips non-alphanumeric
-// characters. Empty tokens are discarded. Sufficient for log-line search.
+// Tokenize lowercases the string and splits on every non-alphanumeric rune,
+// so "foo-bar_baz" yields ["foo", "bar", "baz"]. Empty tokens are discarded.
+// Splitting (rather than stripping) lets queries match individual segments of
+// hyphenated identifiers, error codes, and process names that appear all over
+// log lines.
 func Tokenize(s string) []string {
-	fields := strings.Fields(strings.ToLower(s))
-	out := make([]string, 0, len(fields))
-	for _, f := range fields {
-		clean := stripNonAlnum(f)
-		if clean != "" {
-			out = append(out, clean)
-		}
-	}
-	return out
-}
-
-func stripNonAlnum(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(r)
-		}
-	}
-	return b.String()
+	lower := strings.ToLower(s)
+	fields := strings.FieldsFunc(lower, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	return fields
 }

--- a/src/mcp/bm25_test.go
+++ b/src/mcp/bm25_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"Hello, World!", []string{"hello", "world"}},
+		{"ERROR: failed to connect", []string{"error", "failed", "to", "connect"}},
+		{"   ", nil},
+		{"", nil},
+		{"foo-bar_baz", []string{"foobarbaz"}},
+	}
+	for _, tc := range cases {
+		got := Tokenize(tc.in)
+		if len(got) == 0 && len(tc.want) == 0 {
+			continue
+		}
+		if len(got) != len(tc.want) {
+			t.Fatalf("Tokenize(%q) len = %d, want %d (got %v)", tc.in, len(got), len(tc.want), got)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("Tokenize(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestScoreRanksRelevantDocHigher(t *testing.T) {
+	docs := [][]string{
+		Tokenize("hello world"),
+		Tokenize("error: failed to connect to database"),
+		Tokenize("info: application started"),
+		Tokenize("error handling is important"),
+	}
+	c := NewCorpus(docs, 0, 0)
+
+	hits := c.TopN(Tokenize("error failed"), 10)
+	if len(hits) == 0 {
+		t.Fatalf("expected at least one hit")
+	}
+	if hits[0].DocID != 1 {
+		t.Fatalf("expected doc 1 (error: failed to connect) first, got doc %d with hits %+v", hits[0].DocID, hits)
+	}
+}
+
+func TestScoreEmptyQuery(t *testing.T) {
+	docs := [][]string{
+		Tokenize("alpha beta"),
+		Tokenize("gamma delta"),
+	}
+	c := NewCorpus(docs, 0, 0)
+	scores := c.Score(nil)
+	if len(scores) != len(docs) {
+		t.Fatalf("Score(nil) len = %d, want %d", len(scores), len(docs))
+	}
+	for i, s := range scores {
+		if s != 0 {
+			t.Fatalf("Score(nil)[%d] = %v, want 0", i, s)
+		}
+	}
+}
+
+func TestScoreEmptyCorpus(t *testing.T) {
+	c := NewCorpus(nil, 0, 0)
+	if got := c.Score(Tokenize("anything")); got != nil {
+		t.Fatalf("Score on empty corpus = %v, want nil", got)
+	}
+	if got := c.TopN(Tokenize("anything"), 5); len(got) != 0 {
+		t.Fatalf("TopN on empty corpus = %v, want empty", got)
+	}
+}
+
+func TestTopNCapsResultsAndTieBreaks(t *testing.T) {
+	// Two identical docs produce identical scores; tie-break must be deterministic.
+	// Build token slices directly to avoid the dupword linter flagging the test source.
+	docs := [][]string{
+		{"error", "error", "error"},
+		{"error", "error", "error"},
+		{"nothing", "here"},
+	}
+	c := NewCorpus(docs, 0, 0)
+	hits := c.TopN(Tokenize("error"), 2)
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(hits))
+	}
+	if hits[0].DocID != 0 || hits[1].DocID != 1 {
+		t.Fatalf("tie-break not stable: got %+v", hits)
+	}
+}
+
+func TestQueryWithNoMatchesReturnsNoHits(t *testing.T) {
+	docs := [][]string{
+		Tokenize("alpha beta"),
+		Tokenize("gamma delta"),
+	}
+	c := NewCorpus(docs, 0, 0)
+	if got := c.TopN(Tokenize("zeta"), 5); len(got) != 0 {
+		t.Fatalf("expected no hits, got %v", got)
+	}
+}

--- a/src/mcp/bm25_test.go
+++ b/src/mcp/bm25_test.go
@@ -13,7 +13,8 @@ func TestTokenize(t *testing.T) {
 		{"ERROR: failed to connect", []string{"error", "failed", "to", "connect"}},
 		{"   ", nil},
 		{"", nil},
-		{"foo-bar_baz", []string{"foobarbaz"}},
+		{"foo-bar_baz", []string{"foo", "bar", "baz"}},
+		{"req=12345 status=ok", []string{"req", "12345", "status", "ok"}},
 	}
 	for _, tc := range cases {
 		got := Tokenize(tc.in)

--- a/src/mcp/control_tools.go
+++ b/src/mcp/control_tools.go
@@ -104,9 +104,9 @@ func (s *Server) registerProcessControlTools() {
 
 	s.addTool(
 		mcp.NewTool(controlToolPrefix+"process_logs_search",
-			mcp.WithDescription(`Search process log buffers using BM25 text ranking. Results are ranked by relevance, NOT by time, and may be old or out of chronological order. For the latest output of a single process use pc_process_logs instead.
+			mcp.WithDescription(fmt.Sprintf(`Search process log buffers using BM25 text ranking. Results are ranked by relevance, NOT by time, and may be old or out of chronological order. For the latest output of a single process use %sprocess_logs instead.
 
-Each hit includes chunk_idx (0 = oldest line in the searched window, higher = more recent), so sort hits by chunk_idx descending if you need recency. Process log lines pass through verbatim — timestamps appear in 'text' only when the process itself emits them.`),
+Each hit includes chunk_idx (0 = oldest line in the searched window, higher = more recent), so sort hits by chunk_idx descending if you need recency. Process log lines pass through verbatim — timestamps appear in 'text' only when the process itself emits them.`, controlToolPrefix)),
 			mcp.WithString("query", mcp.Description("Search query (space-separated terms)"), mcp.Required()),
 			mcp.WithString("name", mcp.Description("Process name to search. If omitted, searches every process.")),
 			mcp.WithNumber("top_k", mcp.Description("Number of top results to return (default 20, max 100)")),

--- a/src/mcp/control_tools.go
+++ b/src/mcp/control_tools.go
@@ -101,6 +101,19 @@ func (s *Server) registerProcessControlTools() {
 		),
 		s.handleProcessLogsTruncate,
 	)
+
+	s.addTool(
+		mcp.NewTool(controlToolPrefix+"process_logs_search",
+			mcp.WithDescription(`Search process log buffers using BM25 text ranking. Results are ranked by relevance, NOT by time, and may be old or out of chronological order. For the latest output of a single process use pc_process_logs instead.
+
+Each hit includes chunk_idx (0 = oldest line in the searched window, higher = more recent), so sort hits by chunk_idx descending if you need recency. Process log lines pass through verbatim — timestamps appear in 'text' only when the process itself emits them.`),
+			mcp.WithString("query", mcp.Description("Search query (space-separated terms)"), mcp.Required()),
+			mcp.WithString("name", mcp.Description("Process name to search. If omitted, searches every process.")),
+			mcp.WithNumber("top_k", mcp.Description("Number of top results to return (default 20, max 100)")),
+			mcp.WithNumber("log_limit", mcp.Description("Max log lines to fetch per process before searching (default 500, max 5000)")),
+		),
+		s.handleProcessLogsSearch,
+	)
 }
 
 // ---- project.* tools ------------------------------------------------------
@@ -119,6 +132,13 @@ func (s *Server) registerProjectControlTools() {
 			mcp.WithDescription("Check whether all processes are ready. Returns ready=true only when every process is ready."),
 		),
 		s.handleProjectIsReady,
+	)
+
+	s.addTool(
+		mcp.NewTool(controlToolPrefix+"project_dependency_graph",
+			mcp.WithDescription("Return the project dependency graph: each node carries the process name, current status, readiness, and a depends_on map of upstream processes with their startup conditions (process_started, process_healthy, process_completed, process_log_ready). Useful for diagnosing why a process is stuck Pending."),
+		),
+		s.handleProjectDependencyGraph,
 	)
 }
 
@@ -295,4 +315,114 @@ func (s *Server) handleProjectIsReady(_ context.Context, _ mcp.CallToolRequest) 
 		NotReady: notReady,
 	}
 	return mcp.NewToolResultJSON(result)
+}
+
+// Default and max bounds for pc_process_logs_search.
+const (
+	searchDefaultTopK     = 20
+	searchMaxTopK         = 100
+	searchDefaultLogLimit = 500
+	searchMaxLogLimit     = 5000
+)
+
+// logSearchHit is one entry in the pc_process_logs_search result. ChunkIdx is
+// the line's 0-based index within the per-process tail we searched, not an
+// absolute position in the underlying ring buffer — lines may roll out
+// between calls.
+type logSearchHit struct {
+	Process  string  `json:"process"`
+	ChunkIdx int     `json:"chunk_idx"`
+	Score    float64 `json:"score"`
+	Text     string  `json:"text"`
+}
+
+type logSearchResult struct {
+	Query string         `json:"query"`
+	Hits  []logSearchHit `json:"hits"`
+}
+
+func (s *Server) handleProcessLogsSearch(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	query, err := req.RequireString("query")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	topK := clampInt(req.GetInt("top_k", searchDefaultTopK), searchDefaultTopK, searchMaxTopK)
+	logLimit := clampInt(req.GetInt("log_limit", searchDefaultLogLimit), searchDefaultLogLimit, searchMaxLogLimit)
+
+	procNames, err := s.searchTargetNames(req.GetString("name", ""))
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	var (
+		docs      [][]string
+		lineTexts []string
+		lineProcs []string
+		chunkIdxs []int
+	)
+	for _, pname := range procNames {
+		lines, err := s.runner.GetProcessLog(pname, 0, logLimit)
+		if err != nil {
+			log.Warn().Err(err).Str("process", pname).Msg("pc_process_logs_search: skipping process")
+			continue
+		}
+		for i, line := range lines {
+			docs = append(docs, Tokenize(line))
+			lineTexts = append(lineTexts, line)
+			lineProcs = append(lineProcs, pname)
+			chunkIdxs = append(chunkIdxs, i)
+		}
+	}
+
+	corpus := NewCorpus(docs, 0, 0)
+	hits := corpus.TopN(Tokenize(query), topK)
+
+	result := logSearchResult{Query: query, Hits: make([]logSearchHit, 0, len(hits))}
+	for _, h := range hits {
+		result.Hits = append(result.Hits, logSearchHit{
+			Process:  lineProcs[h.DocID],
+			ChunkIdx: chunkIdxs[h.DocID],
+			Score:    h.Score,
+			Text:     lineTexts[h.DocID],
+		})
+	}
+	return mcp.NewToolResultJSON(result)
+}
+
+// searchTargetNames returns just `name` when provided (and known), otherwise
+// every known process name from the runner.
+func (s *Server) searchTargetNames(name string) ([]string, error) {
+	if name != "" {
+		if _, err := s.runner.GetProcessState(name); err != nil {
+			return nil, fmt.Errorf("unknown process %q: %w", name, err)
+		}
+		return []string{name}, nil
+	}
+	states, err := s.runner.GetProcessesState()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list processes: %w", err)
+	}
+	names := make([]string, 0, len(states.States))
+	for _, st := range states.States {
+		names = append(names, st.Name)
+	}
+	return names, nil
+}
+
+func clampInt(v, fallback, max int) int {
+	if v <= 0 {
+		v = fallback
+	}
+	if v > max {
+		v = max
+	}
+	return v
+}
+
+func (s *Server) handleProjectDependencyGraph(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	graph, err := s.runner.GetDependencyGraph()
+	if err != nil {
+		return mcp.NewToolResultErrorf("failed to get dependency graph: %v", err), nil
+	}
+	return mcp.NewToolResultJSON(graph)
 }

--- a/src/mcp/control_tools.go
+++ b/src/mcp/control_tools.go
@@ -106,7 +106,7 @@ func (s *Server) registerProcessControlTools() {
 		mcp.NewTool(controlToolPrefix+"process_logs_search",
 			mcp.WithDescription(fmt.Sprintf(`Search process log buffers using BM25 text ranking. Results are ranked by relevance, NOT by time, and may be old or out of chronological order. For the latest output of a single process use %sprocess_logs instead.
 
-Each hit includes chunk_idx (0 = oldest line in the searched window, higher = more recent), so sort hits by chunk_idx descending if you need recency. Process log lines pass through verbatim — timestamps appear in 'text' only when the process itself emits them.`, controlToolPrefix)),
+Each hit includes chunk_idx (0 = oldest line in the searched window, higher = more recent), so sort hits by chunk_idx descending if you need recency. Process log lines pass through verbatim — timestamps appear in 'text' only when the process itself emits them. 'truncated': true means the per-process line budget was reduced below log_limit to bound total work.`, controlToolPrefix)),
 			mcp.WithString("query", mcp.Description("Search query (space-separated terms)"), mcp.Required()),
 			mcp.WithString("name", mcp.Description("Process name to search. If omitted, searches every process.")),
 			mcp.WithNumber("top_k", mcp.Description("Number of top results to return (default 20, max 100)")),
@@ -323,6 +323,11 @@ const (
 	searchMaxTopK         = 100
 	searchDefaultLogLimit = 500
 	searchMaxLogLimit     = 5000
+	// searchMaxCorpusLines bounds the total lines tokenized and scored across
+	// all processes in one search. When log_limit * N > this, each process's
+	// budget is reduced to a fair share (most-recent lines kept) and the
+	// result is flagged truncated.
+	searchMaxCorpusLines = 50000
 )
 
 // logSearchHit is one entry in the pc_process_logs_search result. ChunkIdx is
@@ -337,8 +342,9 @@ type logSearchHit struct {
 }
 
 type logSearchResult struct {
-	Query string         `json:"query"`
-	Hits  []logSearchHit `json:"hits"`
+	Query     string         `json:"query"`
+	Truncated bool           `json:"truncated,omitempty"`
+	Hits      []logSearchHit `json:"hits"`
 }
 
 func (s *Server) handleProcessLogsSearch(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -354,6 +360,17 @@ func (s *Server) handleProcessLogsSearch(_ context.Context, req mcp.CallToolRequ
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	perProcCap := logLimit
+	if n := len(procNames); n > 0 {
+		if share := searchMaxCorpusLines / n; share < perProcCap {
+			perProcCap = share
+		}
+	}
+	if perProcCap < 1 {
+		perProcCap = 1
+	}
+	truncated := perProcCap < logLimit
+
 	var (
 		docs      [][]string
 		lineTexts []string
@@ -361,7 +378,7 @@ func (s *Server) handleProcessLogsSearch(_ context.Context, req mcp.CallToolRequ
 		chunkIdxs []int
 	)
 	for _, pname := range procNames {
-		lines, err := s.runner.GetProcessLog(pname, 0, logLimit)
+		lines, err := s.runner.GetProcessLog(pname, 0, perProcCap)
 		if err != nil {
 			log.Warn().Err(err).Str("process", pname).Msg("pc_process_logs_search: skipping process")
 			continue
@@ -377,7 +394,7 @@ func (s *Server) handleProcessLogsSearch(_ context.Context, req mcp.CallToolRequ
 	corpus := NewCorpus(docs, 0, 0)
 	hits := corpus.TopN(Tokenize(query), topK)
 
-	result := logSearchResult{Query: query, Hits: make([]logSearchHit, 0, len(hits))}
+	result := logSearchResult{Query: query, Truncated: truncated, Hits: make([]logSearchHit, 0, len(hits))}
 	for _, h := range hits {
 		result.Hits = append(result.Hits, logSearchHit{
 			Process:  lineProcs[h.DocID],

--- a/src/mcp/control_tools_test.go
+++ b/src/mcp/control_tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -538,6 +539,42 @@ func TestProcessLogsSearch(t *testing.T) {
 		}))
 		if runner.logLimit != searchMaxLogLimit {
 			t.Errorf("expected log_limit clamped to %d, got %d", searchMaxLogLimit, runner.logLimit)
+		}
+	})
+
+	t.Run("truncates when fair share is below log_limit", func(t *testing.T) {
+		// 20 procs * log_limit=5000 = 100k requested, well over the 50k cap.
+		// Fair share collapses to 50000/20 = 2500 per proc, which is below
+		// the requested log_limit, so the result must be flagged truncated.
+		const n = 20
+		states := make([]types.ProcessState, 0, n)
+		logsByName := map[string][]string{}
+		for i := range n {
+			name := fmt.Sprintf("p%d", i)
+			states = append(states, types.ProcessState{Name: name})
+			logsByName[name] = []string{"hello world"}
+		}
+		runner := &fakeRunner{
+			listResult:       &types.ProcessesState{States: states},
+			logResultsByName: logsByName,
+		}
+		s := newTestServer(runner)
+		res, _ := s.handleProcessLogsSearch(context.Background(), callRequest(map[string]any{
+			"query":     "hello",
+			"log_limit": float64(searchMaxLogLimit),
+		}))
+		if resultIsError(res) {
+			t.Fatalf("unexpected tool error: %s", resultText(res))
+		}
+		var got logSearchResult
+		if err := json.Unmarshal([]byte(resultText(res)), &got); err != nil {
+			t.Fatalf("result not valid JSON: %v", err)
+		}
+		if !got.Truncated {
+			t.Errorf("expected truncated=true with %d procs and log_limit=%d", n, searchMaxLogLimit)
+		}
+		if want := searchMaxCorpusLines / n; runner.logLimit != want {
+			t.Errorf("expected per-proc limit %d, got %d", want, runner.logLimit)
 		}
 	})
 }

--- a/src/mcp/control_tools_test.go
+++ b/src/mcp/control_tools_test.go
@@ -13,37 +13,37 @@ import (
 
 // fakeRunner records calls and returns canned data for test assertions.
 type fakeRunner struct {
-	startCalled    string
-	startErr       error
-	stopCalled     []string
-	stopResult     map[string]string
-	stopErr        error
-	restartCalled  string
-	restartErr     error
-	scaleCalled    string
-	scaleValue     int
-	scaleErr       error
-	getStateName   string
-	getStateResult *types.ProcessState
-	getStateErr    error
-	listResult     *types.ProcessesState
-	listErr        error
-	portsName      string
-	portsResult    *types.ProcessPorts
-	portsErr       error
-	projectMem     bool
-	projectResult  *types.ProjectState
-	projectErr     error
-	logName        string
-	logOffset      int
-	logLimit       int
-	logResult      []string
+	startCalled      string
+	startErr         error
+	stopCalled       []string
+	stopResult       map[string]string
+	stopErr          error
+	restartCalled    string
+	restartErr       error
+	scaleCalled      string
+	scaleValue       int
+	scaleErr         error
+	getStateName     string
+	getStateResult   *types.ProcessState
+	getStateErr      error
+	listResult       *types.ProcessesState
+	listErr          error
+	portsName        string
+	portsResult      *types.ProcessPorts
+	portsErr         error
+	projectMem       bool
+	projectResult    *types.ProjectState
+	projectErr       error
+	logName          string
+	logOffset        int
+	logLimit         int
+	logResult        []string
 	logResultsByName map[string][]string
-	logErr         error
-	truncCalled    string
-	truncErr       error
-	graphResult    *types.DependencyGraph
-	graphErr       error
+	logErr           error
+	truncCalled      string
+	truncErr         error
+	graphResult      *types.DependencyGraph
+	graphErr         error
 }
 
 func (f *fakeRunner) StartProcess(name string) error {
@@ -91,7 +91,7 @@ func (f *fakeRunner) GetProcessLog(name string, offsetFromEnd, limit int) ([]str
 func (f *fakeRunner) GetDependencyGraph() (*types.DependencyGraph, error) {
 	return f.graphResult, f.graphErr
 }
-func (f *fakeRunner) GetProcessLogLength(_ string) int       { return 0 }
+func (f *fakeRunner) GetProcessLogLength(_ string) int            { return 0 }
 func (f *fakeRunner) SetProcessInfo(_ *types.ProcessConfig) error { return nil }
 func (f *fakeRunner) TruncateProcessLogs(name string) error {
 	f.truncCalled = name

--- a/src/mcp/control_tools_test.go
+++ b/src/mcp/control_tools_test.go
@@ -38,9 +38,12 @@ type fakeRunner struct {
 	logOffset      int
 	logLimit       int
 	logResult      []string
+	logResultsByName map[string][]string
 	logErr         error
 	truncCalled    string
 	truncErr       error
+	graphResult    *types.DependencyGraph
+	graphErr       error
 }
 
 func (f *fakeRunner) StartProcess(name string) error {
@@ -80,7 +83,13 @@ func (f *fakeRunner) GetProcessLog(name string, offsetFromEnd, limit int) ([]str
 	f.logName = name
 	f.logOffset = offsetFromEnd
 	f.logLimit = limit
+	if f.logResultsByName != nil {
+		return f.logResultsByName[name], f.logErr
+	}
 	return f.logResult, f.logErr
+}
+func (f *fakeRunner) GetDependencyGraph() (*types.DependencyGraph, error) {
+	return f.graphResult, f.graphErr
 }
 func (f *fakeRunner) GetProcessLogLength(_ string) int       { return 0 }
 func (f *fakeRunner) SetProcessInfo(_ *types.ProcessConfig) error { return nil }
@@ -423,5 +432,160 @@ func TestRegisterControlTools(t *testing.T) {
 	s := newTestServer(runner)
 	if err := s.RegisterControlTools(); err != nil {
 		t.Fatalf("RegisterControlTools failed: %v", err)
+	}
+}
+
+func TestProcessLogsSearch(t *testing.T) {
+	t.Run("ranks single process", func(t *testing.T) {
+		runner := &fakeRunner{
+			getStateResult: &types.ProcessState{Name: "web"},
+			logResultsByName: map[string][]string{
+				"web": {
+					"INFO server starting",
+					"ERROR database connection failed",
+					"INFO request served",
+				},
+			},
+		}
+		s := newTestServer(runner)
+		res, _ := s.handleProcessLogsSearch(context.Background(), callRequest(map[string]any{
+			"query": "database error",
+			"name":  "web",
+		}))
+		if resultIsError(res) {
+			t.Fatalf("unexpected tool error: %s", resultText(res))
+		}
+		var got logSearchResult
+		if err := json.Unmarshal([]byte(resultText(res)), &got); err != nil {
+			t.Fatalf("result not valid JSON: %v", err)
+		}
+		if got.Query != "database error" {
+			t.Errorf("query echo wrong: %q", got.Query)
+		}
+		if len(got.Hits) == 0 {
+			t.Fatal("expected at least one hit")
+		}
+		if !strings.Contains(got.Hits[0].Text, "database connection failed") {
+			t.Errorf("expected DB error line ranked first, got %q", got.Hits[0].Text)
+		}
+		if got.Hits[0].Process != "web" || got.Hits[0].ChunkIdx != 1 {
+			t.Errorf("hit metadata wrong: process=%q chunk_idx=%d", got.Hits[0].Process, got.Hits[0].ChunkIdx)
+		}
+	})
+
+	t.Run("searches all processes when name omitted", func(t *testing.T) {
+		runner := &fakeRunner{
+			listResult: &types.ProcessesState{States: []types.ProcessState{
+				{Name: "a"}, {Name: "b"},
+			}},
+			logResultsByName: map[string][]string{
+				"a": {"alpha banana"},
+				"b": {"banana cherry"},
+			},
+		}
+		s := newTestServer(runner)
+		res, _ := s.handleProcessLogsSearch(context.Background(), callRequest(map[string]any{
+			"query": "banana",
+		}))
+		if resultIsError(res) {
+			t.Fatalf("unexpected tool error: %s", resultText(res))
+		}
+		var got logSearchResult
+		_ = json.Unmarshal([]byte(resultText(res)), &got)
+		if len(got.Hits) != 2 {
+			t.Errorf("expected 2 hits across processes, got %d", len(got.Hits))
+		}
+		seen := map[string]bool{}
+		for _, h := range got.Hits {
+			seen[h.Process] = true
+		}
+		if !seen["a"] || !seen["b"] {
+			t.Errorf("expected hits from both a and b, got %+v", got.Hits)
+		}
+	})
+
+	t.Run("missing query", func(t *testing.T) {
+		s := newTestServer(&fakeRunner{})
+		res, _ := s.handleProcessLogsSearch(context.Background(), callRequest(map[string]any{}))
+		if !resultIsError(res) {
+			t.Fatal("expected tool error for missing query")
+		}
+	})
+
+	t.Run("unknown process", func(t *testing.T) {
+		runner := &fakeRunner{getStateErr: errors.New("no such process")}
+		s := newTestServer(runner)
+		res, _ := s.handleProcessLogsSearch(context.Background(), callRequest(map[string]any{
+			"query": "x",
+			"name":  "ghost",
+		}))
+		if !resultIsError(res) {
+			t.Fatal("expected tool error for unknown process")
+		}
+	})
+
+	t.Run("clamps top_k and log_limit", func(t *testing.T) {
+		runner := &fakeRunner{
+			getStateResult:   &types.ProcessState{Name: "web"},
+			logResultsByName: map[string][]string{"web": {"hello"}},
+		}
+		s := newTestServer(runner)
+		_, _ = s.handleProcessLogsSearch(context.Background(), callRequest(map[string]any{
+			"query":     "hello",
+			"name":      "web",
+			"top_k":     float64(99999),
+			"log_limit": float64(99999),
+		}))
+		if runner.logLimit != searchMaxLogLimit {
+			t.Errorf("expected log_limit clamped to %d, got %d", searchMaxLogLimit, runner.logLimit)
+		}
+	})
+}
+
+func TestProjectDependencyGraph(t *testing.T) {
+	t.Run("returns runner graph", func(t *testing.T) {
+		graph := &types.DependencyGraph{
+			Nodes: map[string]*types.DependencyNode{
+				"web": {Name: "web", Status: "Running"},
+				"db":  {Name: "db", Status: "Running"},
+			},
+		}
+		runner := &fakeRunner{graphResult: graph}
+		s := newTestServer(runner)
+		res, _ := s.handleProjectDependencyGraph(context.Background(), callRequest(nil))
+		if resultIsError(res) {
+			t.Fatalf("unexpected tool error: %s", resultText(res))
+		}
+		if !strings.Contains(resultText(res), `"web"`) || !strings.Contains(resultText(res), `"db"`) {
+			t.Errorf("expected web and db nodes in payload, got %s", resultText(res))
+		}
+	})
+
+	t.Run("runner error", func(t *testing.T) {
+		runner := &fakeRunner{graphErr: errors.New("boom")}
+		s := newTestServer(runner)
+		res, _ := s.handleProjectDependencyGraph(context.Background(), callRequest(nil))
+		if !resultIsError(res) {
+			t.Fatal("expected tool error from runner failure")
+		}
+		if !strings.Contains(resultText(res), "boom") {
+			t.Errorf("expected error text to include runner err, got %q", resultText(res))
+		}
+	})
+}
+
+func TestClampInt(t *testing.T) {
+	cases := []struct {
+		in, fallback, max, want int
+	}{
+		{0, 20, 100, 20},
+		{-5, 20, 100, 20},
+		{50, 20, 100, 50},
+		{500, 20, 100, 100},
+	}
+	for _, c := range cases {
+		if got := clampInt(c.in, c.fallback, c.max); got != c.want {
+			t.Errorf("clampInt(%d,%d,%d) = %d, want %d", c.in, c.fallback, c.max, got, c.want)
+		}
 	}
 }

--- a/src/mcp/server.go
+++ b/src/mcp/server.go
@@ -28,6 +28,7 @@ type ProcessRunner interface {
 	GetProcessLogLength(name string) int
 	SetProcessInfo(config *types.ProcessConfig) error
 	TruncateProcessLogs(name string) error
+	GetDependencyGraph() (*types.DependencyGraph, error)
 }
 
 // Server wraps the MCP server and integrates with process-compose

--- a/www/docs/mcp-server.md
+++ b/www/docs/mcp-server.md
@@ -247,8 +247,10 @@ When enabled, the MCP server starts even if no process has an `mcp:` section, an
 | `pc_process_ports` | Get TCP/UDP ports a process is listening on | `name: string` |
 | `pc_process_logs` | Fetch the most recent log lines (one-shot) | `name: string`, `tail: integer` (default 100), `offset_from_end: integer` (default 0) |
 | `pc_process_logs_truncate` | Truncate the log buffer for a process | `name: string` |
+| `pc_process_logs_search` | Search log buffers using BM25 ranking across one or all processes | `query: string`, `name: string` (optional, all if omitted), `top_k: integer` (default 20, max 100), `log_limit: integer` (default 500, max 5000) |
 | `pc_project_state` | Get overall project state (uptime, counts, optional memory) | `with_memory: boolean` (default false) |
 | `pc_project_is_ready` | Check whether all processes are ready | _none_ |
+| `pc_project_dependency_graph` | Get the project dependency graph (nodes, statuses, upstream conditions) | _none_ |
 
 The `pc_` prefix avoids collisions with user-defined tools — it is safe to have a user process named `start` alongside `pc_process_start`.
 

--- a/www/docs/mcp-server.md
+++ b/www/docs/mcp-server.md
@@ -258,6 +258,8 @@ The `pc_` prefix avoids collisions with user-defined tools — it is safe to hav
 
 The MCP server can host both kinds of tools at once — user-defined process tools (from per-process `mcp:` blocks) and the built-in `pc_*` control tools.
 
+`pc_process_logs_search` caps total work at 50,000 log lines per call. When `log_limit × <process count>` would exceed that, each process's budget is reduced to a fair share (most-recent lines kept) and the response includes `"truncated": true`.
+
 ## Complete Examples
 
 ### Log Analysis Tool


### PR DESCRIPTION
Adds two extra functions to the new MCP server:

- `pc_process_logs_search` which does semantic search across logs. This is helpful for e.g. very spammy logs where tailing would overwhelm the context, or to search across processes.
- `pc_project_dependency_graph` which shows deps between processes. Useful for e.g. diagnosing startups order related issue or simply understanding why a process is waiting to boot.

See #460