### PR TITLE
fix(app): scheduled processes added via project update now register with the scheduler and respect run_on_start

### DIFF
--- a/src/app/project_runner.go
+++ b/src/app/project_runner.go
@@ -1199,6 +1199,11 @@ func (p *ProjectRunner) removeProcess(name string) error {
 	p.procConfMutex.Lock()
 	delete(p.project.Processes, name)
 	p.procConfMutex.Unlock()
+	if sched := p.processScheduler.Load(); sched != nil {
+		if err := sched.RemoveProcess(name); err != nil {
+			log.Err(err).Msgf("Failed to remove schedule for process %s", name)
+		}
+	}
 	running := p.getRunningProcess(name)
 	if running != nil {
 		err := running.shutDownNoRestart()
@@ -1220,6 +1225,22 @@ func (p *ProjectRunner) addProcessAndRun(proc types.ProcessConfig) {
 	p.project.Processes[proc.ReplicaName] = proc
 	p.procConfMutex.Unlock()
 	p.initProcessLog(proc.ReplicaName)
+	// Scheduled processes must be registered with the scheduler instead of
+	// being run immediately. Matches the startup-loop behavior in Run(): the
+	// scheduler owns lifecycle for any process with a Schedule, and
+	// runProcess is skipped for them.
+	if proc.Schedule != nil && proc.Schedule.IsScheduled() {
+		if sched := p.processScheduler.Load(); sched != nil {
+			if err := sched.AddProcess(proc.ReplicaName, proc.Schedule); err != nil {
+				log.Err(err).Msgf("Failed to schedule process %s", proc.ReplicaName)
+			} else if proc.Disabled {
+				if err := sched.PauseProcess(proc.ReplicaName); err != nil {
+					log.Err(err).Msgf("Failed to pause schedule for disabled process %s", proc.ReplicaName)
+				}
+			}
+		}
+		return
+	}
 	if !proc.IsDeferred() {
 		p.runProcess(&proc)
 	}

--- a/src/app/system_test.go
+++ b/src/app/system_test.go
@@ -967,6 +967,121 @@ func TestUpdateProject(t *testing.T) {
 	}
 }
 
+// TestUpdateProject_ScheduledProcess covers the scheduled-process paths
+// through UpdateProject: add, schedule-change, and remove. Pre-fix, adding a
+// scheduled process via UpdateProject would (1) fire it immediately even with
+// run_on_start: false and (2) never call processScheduler.AddProcess — so
+// next_run_time stayed nil and the cron was silently dropped forever. The
+// existing TestUpdateProject above does not exercise scheduled namespaces.
+func TestUpdateProject_ScheduledProcess(t *testing.T) {
+	regular := "regular-proc"
+	scheduled := "scheduled-proc"
+	shell := command.DefaultShellConfig()
+	p, err := NewProjectRunner(&ProjectOpts{
+		project: &types.Project{
+			ShellConfig: shell,
+			Processes: map[string]types.ProcessConfig{
+				regular: {
+					Name:        regular,
+					ReplicaName: regular,
+					Executable:  shell.ShellCommand,
+					Args:        []string{shell.ShellArgument, "sleep 5"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	go func() {
+		if err := p.Run(); err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Add a scheduled-cron process via UpdateProject.
+	project := &types.Project{
+		ShellConfig: shell,
+		Processes: map[string]types.ProcessConfig{
+			regular: {
+				Name:        regular,
+				ReplicaName: regular,
+				Executable:  shell.ShellCommand,
+				Args:        []string{shell.ShellArgument, "sleep 5"},
+			},
+			scheduled: {
+				Name:        scheduled,
+				ReplicaName: scheduled,
+				Executable:  shell.ShellCommand,
+				Args:        []string{shell.ShellArgument, "echo scheduled"},
+				Schedule: &types.ScheduleConfig{
+					Cron: "0 8 * * *",
+				},
+			},
+		},
+	}
+	status, err := p.UpdateProject(project)
+	if err != nil {
+		t.Fatalf("UpdateProject(add scheduled) returned error: %v", err)
+	}
+	if status[scheduled] != types.ProcessUpdateAdded {
+		t.Errorf("Scheduled process status is %s want %s", status[scheduled], types.ProcessUpdateAdded)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the scheduler was actually registered (regression for the bug
+	// where addProcessAndRun never called processScheduler.AddProcess).
+	sched := p.processScheduler.Load()
+	if sched == nil {
+		t.Fatal("processScheduler should be initialized")
+	}
+	if !sched.IsScheduled(scheduled) {
+		t.Error("Scheduled process should be registered with the scheduler")
+	}
+
+	// Update the schedule's cron expression. Pre-fix, Compare omitted the
+	// Schedule field and treated this as a no-op (status would be missing
+	// from the result map).
+	project.Processes[scheduled] = types.ProcessConfig{
+		Name:        scheduled,
+		ReplicaName: scheduled,
+		Executable:  shell.ShellCommand,
+		Args:        []string{shell.ShellArgument, "echo scheduled"},
+		Schedule: &types.ScheduleConfig{
+			Cron: "0 9 * * *",
+		},
+	}
+	status, err = p.UpdateProject(project)
+	if err != nil {
+		t.Fatalf("UpdateProject(change cron) returned error: %v", err)
+	}
+	if status[scheduled] != types.ProcessUpdateUpdated {
+		t.Errorf("Schedule change should be detected as Updated, got %s", status[scheduled])
+	}
+	time.Sleep(100 * time.Millisecond)
+	if !sched.IsScheduled(scheduled) {
+		t.Error("Scheduled process should remain registered after a schedule change")
+	}
+
+	// Remove the scheduled process. Pre-fix, removeProcess did not call
+	// scheduler.RemoveProcess so the entry stayed in the schedules map.
+	project = &types.Project{
+		ShellConfig: shell,
+		Processes: map[string]types.ProcessConfig{
+			regular: project.Processes[regular],
+		},
+	}
+	_, err = p.UpdateProject(project)
+	if err != nil {
+		t.Fatalf("UpdateProject(remove scheduled) returned error: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if sched.IsScheduled(scheduled) {
+		t.Error("Removed scheduled process should be deregistered from the scheduler")
+	}
+}
+
 func assertProcessStatus(t *testing.T, proc *Process, procName string, wantStatus string) {
 	t.Helper()
 	if proc == nil {

--- a/src/scheduler/scheduler.go
+++ b/src/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -175,6 +176,35 @@ func (s *Scheduler) PauseProcess(name string) error {
 		return err
 	}
 	return nil
+}
+
+// RemoveProcess fully removes a scheduled process — both its gocron job and
+// its entry in the scheduler's tracking map. Use this when a process is being
+// deleted from the project. To temporarily disable a process's schedule while
+// keeping the entry tracked (so ResumeProcess can re-arm it later), use
+// PauseProcess instead.
+//
+// If gocron's internal job table no longer has the job (e.g. it was already
+// shut down, or a race window between NewJob and the next scheduler tick),
+// we still clean up our tracking map and treat the absence as success — the
+// caller's intent is "make this process unscheduled" which both paths achieve.
+func (s *Scheduler) RemoveProcess(name string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	entry, ok := s.schedules[name]
+	if !ok {
+		return nil
+	}
+	var err error
+	if entry.Job != nil {
+		if rmErr := s.gocronScheduler.RemoveJob(entry.Job.ID()); rmErr != nil && !errors.Is(rmErr, gocron.ErrJobNotFound) {
+			err = rmErr
+		}
+		entry.Job = nil
+	}
+	delete(s.schedules, name)
+	log.Debug().Msgf("Removed scheduled process %s", name)
+	return err
 }
 
 // ResumeProcess resumes a paused scheduled job.

--- a/src/scheduler/scheduler_test.go
+++ b/src/scheduler/scheduler_test.go
@@ -273,3 +273,77 @@ func TestScheduler_PauseResume(t *testing.T) {
 		t.Error("GetNextRunTime() should return non-nil for resumed process")
 	}
 }
+
+func TestScheduler_RemoveProcess(t *testing.T) {
+	mock := &mockProcessStarter{}
+	s, _ := New(mock)
+	s.Start()
+	defer func() { _ = s.Stop() }()
+
+	config := &types.ScheduleConfig{Interval: "1h"}
+	_ = s.AddProcess("test-remove", config)
+
+	if !s.IsScheduled("test-remove") {
+		t.Fatal("Setup: AddProcess should have registered the process")
+	}
+
+	if err := s.RemoveProcess("test-remove"); err != nil {
+		t.Errorf("RemoveProcess() returned error: %v", err)
+	}
+
+	if s.IsScheduled("test-remove") {
+		t.Error("RemoveProcess() should remove entry from schedules map")
+	}
+	if s.GetNextRunTime("test-remove") != nil {
+		t.Error("GetNextRunTime() should return nil for removed process")
+	}
+}
+
+func TestScheduler_RemoveProcess_Unknown(t *testing.T) {
+	mock := &mockProcessStarter{}
+	s, _ := New(mock)
+
+	if err := s.RemoveProcess("never-added"); err != nil {
+		t.Errorf("RemoveProcess() on unknown process should be a no-op, got: %v", err)
+	}
+}
+
+func TestScheduler_RemoveProcess_AlreadyPaused(t *testing.T) {
+	mock := &mockProcessStarter{}
+	s, _ := New(mock)
+	s.Start()
+	defer func() { _ = s.Stop() }()
+
+	config := &types.ScheduleConfig{Interval: "1h"}
+	_ = s.AddProcess("test-paused-remove", config)
+	_ = s.PauseProcess("test-paused-remove")
+
+	if err := s.RemoveProcess("test-paused-remove"); err != nil {
+		t.Errorf("RemoveProcess() on paused process returned error: %v", err)
+	}
+	if s.IsScheduled("test-paused-remove") {
+		t.Error("RemoveProcess() should clean up the entry even when already paused")
+	}
+}
+
+// TestScheduler_RemoveProcess_GocronAlreadyShutdown verifies the tolerance for
+// the gocron.ErrJobNotFound case — the entry must be removed from our tracking
+// map even if gocron has already lost the underlying job (e.g. due to a
+// previous Stop or a race window). The caller's intent is "make this name
+// unscheduled" and both paths should achieve that.
+func TestScheduler_RemoveProcess_GocronAlreadyShutdown(t *testing.T) {
+	mock := &mockProcessStarter{}
+	s, _ := New(mock)
+	s.Start()
+
+	config := &types.ScheduleConfig{Interval: "1h"}
+	_ = s.AddProcess("test-shutdown-remove", config)
+	_ = s.Stop() // gocron jobs are wiped on shutdown
+
+	if err := s.RemoveProcess("test-shutdown-remove"); err != nil {
+		t.Errorf("RemoveProcess() after Stop should tolerate ErrJobNotFound, got: %v", err)
+	}
+	if s.IsScheduled("test-shutdown-remove") {
+		t.Error("RemoveProcess() should clean up the entry even after scheduler Stop")
+	}
+}

--- a/src/types/process.go
+++ b/src/types/process.go
@@ -139,7 +139,8 @@ func (p *ProcessConfig) Compare(another *ProcessConfig) bool {
 		!reflect.DeepEqual(p.DependsOn, another.DependsOn) ||
 		!reflect.DeepEqual(p.RestartPolicy, another.RestartPolicy) ||
 		!reflect.DeepEqual(p.Environment, another.Environment) ||
-		!reflect.DeepEqual(p.Args, another.Args) {
+		!reflect.DeepEqual(p.Args, another.Args) ||
+		!reflect.DeepEqual(p.Schedule, another.Schedule) {
 		//diffs := compareStructs(*p, *another)
 		//log.Warn().Msgf("Structs are different: %s", diffs)
 		return false

--- a/src/types/process_test.go
+++ b/src/types/process_test.go
@@ -121,6 +121,62 @@ func TestCompareProcessConfigs(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "inequal process configs — schedule cron differs",
+			p: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: &ScheduleConfig{Cron: "0 8 * * *"},
+			},
+			another: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: &ScheduleConfig{Cron: "0 9 * * *"},
+			},
+			expected: false,
+		},
+		{
+			name: "inequal process configs — schedule run_on_start differs",
+			p: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: &ScheduleConfig{Interval: "1h", RunOnStart: false},
+			},
+			another: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: &ScheduleConfig{Interval: "1h", RunOnStart: true},
+			},
+			expected: false,
+		},
+		{
+			name: "inequal process configs — schedule added (nil vs set)",
+			p: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: nil,
+			},
+			another: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: &ScheduleConfig{Cron: "0 8 * * *"},
+			},
+			expected: false,
+		},
+		{
+			name: "equal process configs — identical schedules",
+			p: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: &ScheduleConfig{Cron: "0 8 * * *", MaxConcurrent: 1},
+			},
+			another: &ProcessConfig{
+				Name:     "test",
+				Command:  "cmd",
+				Schedule: &ScheduleConfig{Cron: "0 8 * * *", MaxConcurrent: 1},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Three closely related bugs in `UpdateProject` (CLI: `process-compose project update`, REST: `POST /project`) cause scheduled processes to misbehave when added, modified, or compared as part of a running-project update:

1. **A new scheduled process added via `project update` fires IMMEDIATELY**, ignoring `run_on_start: false`.
2. **The same new scheduled process is never registered with the scheduler** — `next_run_time` stays nil and the cron is silently dropped forever.
3. **Changing only a scheduled process's `cron`/`interval`/`run_on_start`/`timezone` is detected as no-change** by `ProcessConfig.Compare`, so the new schedule is silently ignored.

Live evidence from my setup (Mac, 16 daemons supervised, v1.110.0): I appended one scheduled-cron entry to the project YAML and ran `process-compose project update -f <yaml>`. The new entry fired immediately and got "orphaned" — `next_run_time: null` — so its `0 8 * * *` cron would never have fired again until a full supervisor restart.

## The bug

### (1) Immediate fire on add — `src/app/project_runner.go`

`UpdateProject` routes new entries to [`addProcessAndRun`](https://github.com/F1bonacc1/process-compose/blob/v1.110.0/src/app/project_runner.go#L1212-L1223):

```go
func (p *ProjectRunner) addProcessAndRun(proc types.ProcessConfig) {
    ...
    p.initProcessLog(proc.ReplicaName)
    if !proc.IsDeferred() {
        p.runProcess(&proc)   // <-- unconditional spawn
    }
}
```

`IsDeferred()` returns true only for `IsForeground || Disabled` — it does **not** consider `Schedule`. The startup loop has the correct guard ([lines 186-189](https://github.com/F1bonacc1/process-compose/blob/v1.110.0/src/app/project_runner.go#L186-L189)) — `addProcessAndRun` is just missing the same one.

### (2) Schedule orphaned — `src/scheduler/scheduler.go` + `src/app/project_runner.go`

`processScheduler.AddProcess` is called in exactly one place — the startup `Run()` loop at [line 169](https://github.com/F1bonacc1/process-compose/blob/v1.110.0/src/app/project_runner.go#L169). Neither `UpdateProject`, `UpdateProcess`, `addProcessAndRun`, `StartProcess`, nor `RestartProcess` register new entries with the scheduler. A scheduled process added at runtime is permanently orphaned from gocron.

Symmetrically, `removeProcess` never deregisters from the scheduler — there's no `Scheduler.RemoveProcess` method at all (only `PauseProcess`, which keeps the entry in `s.schedules` so `ResumeProcess` can re-arm it).

### (3) Compare omits Schedule — `src/types/process.go`

[`ProcessConfig.Compare` (lines 107-149)](https://github.com/F1bonacc1/process-compose/blob/v1.110.0/src/types/process.go#L107-L149) walks ~25 fields by direct compare or `reflect.DeepEqual`. `Schedule` is literally absent from the field list. The function predates scheduled processes (introduced in v1.87.0); the maintenance was never done.

If only `Schedule.Cron` changes between the running config and the new YAML, Compare returns `true` (equal) → UpdateProject classifies the process as up-to-date → the cron change is silently ignored.

## The fix

Three minimal source changes + one new scheduler method:

**`src/scheduler/scheduler.go`** — add `RemoveProcess` (full removal, distinct from `PauseProcess`'s preserve-for-resume semantics). Tolerates `gocron.ErrJobNotFound` (the underlying gocron job table is eventually-consistent against `NewJob` and may have already wiped the job on shutdown) and always cleans up the local tracking map:

```go
func (s *Scheduler) RemoveProcess(name string) error {
    s.mutex.Lock()
    defer s.mutex.Unlock()
    entry, ok := s.schedules[name]
    if !ok { return nil }
    var err error
    if entry.Job != nil {
        if rmErr := s.gocronScheduler.RemoveJob(entry.Job.ID()); rmErr != nil && !errors.Is(rmErr, gocron.ErrJobNotFound) {
            err = rmErr
        }
        entry.Job = nil
    }
    delete(s.schedules, name)
    return err
}
```

**`src/app/project_runner.go`** — patch `addProcessAndRun` to route scheduled processes to `Scheduler.AddProcess` and **skip `runProcess`**. Mirrors the startup-loop semantics. Patch `removeProcess` to call `Scheduler.RemoveProcess` for full deregistration.

**`src/types/process.go`** — add `!reflect.DeepEqual(p.Schedule, another.Schedule)` to Compare's DeepEqual chain.

Why patching `addProcessAndRun` (rather than branching in each call site): the helper is called from both `UpdateProject` (new procs) and `UpdateProcess` (the remove-then-re-add path). Both call sites should treat scheduled processes the same way. One change in the helper covers both, and means future call sites get the right behavior for free.

## Minimal reproduction

```bash
mkdir -p /tmp/pc-bug-1801 && cd /tmp/pc-bug-1801
cat > project.yaml <<'EOF'
version: "0.5"
processes:
  ticker:
    command: echo "ticker would fire"
    namespace: scheduled-cron
    schedule:
      cron: "0 8 * * *"
      run_on_start: false
EOF

cat > project-after.yaml <<'EOF'
version: "0.5"
processes:
  ticker:
    command: echo "ticker would fire"
    namespace: scheduled-cron
    schedule:
      cron: "0 8 * * *"
      run_on_start: false
  newcomer:
    command: echo "this should NOT fire on update"
    namespace: scheduled-cron
    schedule:
      cron: "0 0 1 1 *"
      run_on_start: false
EOF

# Terminal 1: start supervisor with the smaller config
process-compose up -f project.yaml --tui=false &
SUPERVISOR=$!
sleep 2

# Terminal 1: append a new scheduled entry via project update
process-compose project update -f project-after.yaml

# Before fix: newcomer fired immediately ("this should NOT fire on update")
#             AND curl localhost:8080/process/newcomer | jq .next_run_time → null
# After fix:  newcomer is silent
#             AND curl localhost:8080/process/newcomer | jq .next_run_time → "2027-01-01T00:00:00Z"

curl -s localhost:8080/process/newcomer | python3 -c "import sys,json; p=json.load(sys.stdin); print(f\"next_run_time: {p.get('next_run_time')}\")"

kill $SUPERVISOR
```

## Before / After (real environment)

I run a 16-process supervisor on macOS. I added one scheduled-cron entry to the YAML and ran `project update`. Captured `curl localhost:8080/processes`:

**Before fix (v1.110.0):**
```
test-entry: status=Completed, pid=69358, process_start_time=2026-05-23T00:53:54.907+02:00, next_run_time=null
```
→ Fired immediately at the update moment, orphaned from scheduler.

**After fix (this PR):**
```
test-entry: status=Scheduled, pid=0, process_start_time=null, next_run_time=2027-01-01T00:00:00+01:00
```
→ Quiet, scheduler-registered, will fire at the configured time.

## Tests

Three test surfaces lock in the fix:

- **`src/scheduler/scheduler_test.go`** — 4 cases for the new `RemoveProcess` (found, unknown, already-paused, gocron-shutdown-tolerance).
- **`src/types/process_test.go`** — 4 cases extending the table-driven `TestCompareProcessConfigs`: different cron, different `run_on_start`, nil-vs-set Schedule, identical schedules equal.
- **`src/app/system_test.go`** — `TestUpdateProject_ScheduledProcess` end-to-end through `UpdateProject`: add → schedule-change → remove. Separate from the existing `TestUpdateProject` so the pre-fix behavior assertion in that test stays untouched.

`make testrace` passes locally. `make lint` clean. `make ci`'s `build-nix` step skipped (non-Nix host).

There's one pre-existing failure in `TestBuildProcessEnvironment/PC_PROC_NAME` + `PC_REPLICA_NUM` on `main` (unrelated to this change — environment-variable test, no scheduler involvement). Confirmed by running `go test ./src/app/ -run TestBuildProcessEnvironment` against unmodified `main`.

## Why this fix vs. alternatives

- **Branch in each call site instead of the helper.** Considered. Would require duplicating the same logic in `UpdateProject`'s new-procs loop and `UpdateProcess`'s add-after-remove path. The helper is the canonical "add a process to the runtime" entry point — putting the schedule guard there means the next caller (e.g. a future scaling path) gets it for free.
- **Skip the Compare fix and just let `UpdateProcess`'s second compare catch it.** `UpdateProcess` does call `AssignProcessExecutableAndArgs` before its own Compare, but `UpdateProject` classifies entries via Compare *before* dispatching to `UpdateProcess` — and Schedule-only changes never make it past the first classification. Compare needs to know about Schedule directly.
- **Reuse `PauseProcess` instead of adding `RemoveProcess`.** Pause keeps the entry in `s.schedules` so `ResumeProcess` can re-arm it. For a process being deleted from the project entirely, that's a leak — and a name collision risk if a later `AddProcess` reuses the same name. The two operations have distinct contracts.

## Related

- #487 — recent loader-path correctness fix (`fix(loader): persist user-supplied FileNames, not the extends-mutated slice`). Same family of bug: state leak across reload. Cross-referencing as precedent — not a dependency.
- #299 (open) — "No-downtime rollout" feature request. This PR is bug-fix scope, not the rollout feature; it doesn't close #299 but it does remove one class of "downtime cause" (scheduled-process orphaning).
- #381 (closed) — the PR that added `project update` to the HTTP API. The current PR exposes that endpoint's scheduled-process path was never wired up correctly.

I have one more open question — a separate bouncing issue I observed on the live supervisor where two pre-existing scheduled processes were classified as "Updated" on a `project update` against a structurally-identical YAML, causing a full pulsar-postgres restart. The source-level explanation (`UpdateProject` calling Compare before `AssignProcessExecutableAndArgs` while the in-memory copy is already assigned) doesn't quite match the code in `loader.Load` which already runs `assignExecutableAndArgs` before returning. I'm filing that separately as an issue with debug-log evidence; happy to follow up with another PR if you confirm the diagnosis.

Thanks for `process-compose` — it's been a quiet workhorse for a 16-daemon Mac supervisor setup of mine for the past few weeks.
