### PR TITLE
Fix deadlock that wedges the logs WebSocket for an entire process

### DIFF
--- a/src/api/pc_api.go
+++ b/src/api/pc_api.go
@@ -3,7 +3,6 @@ package api
 import (
 	"net/http"
 	"strconv"
-	"sync"
 
 	"github.com/f1bonacc1/process-compose/src/types"
 
@@ -28,7 +27,6 @@ import (
 
 type PcApi struct {
 	project app.IProject
-	wsMtx   sync.Mutex
 }
 
 func NewPcApi(project app.IProject) *PcApi {

--- a/src/api/state_ws_api.go
+++ b/src/api/state_ws_api.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/f1bonacc1/process-compose/src/app"
 	"github.com/f1bonacc1/process-compose/src/pclog"
@@ -136,9 +137,8 @@ func (api *PcApi) handleStateStream(ws *websocket.Conn, observer *stateWsObserve
 	var writeMu sync.Mutex
 	writeJSON := func(ev types.ProcessStateEvent) error {
 		writeMu.Lock()
-		api.wsMtx.Lock()
+		_ = ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
 		err := ws.WriteJSON(&ev)
-		api.wsMtx.Unlock()
 		writeMu.Unlock()
 		return err
 	}

--- a/src/api/ws_api.go
+++ b/src/api/ws_api.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/f1bonacc1/process-compose/src/app"
@@ -46,6 +47,7 @@ func (api *PcApi) HandleLogsStream(c *gin.Context) {
 	}
 
 	done := make(chan struct{})
+	wsWriteMtx := &sync.Mutex{}
 	if follow {
 		go handleIncoming(ws, done)
 	}
@@ -56,6 +58,32 @@ func (api *PcApi) HandleLogsStream(c *gin.Context) {
 		logChan := make(chan LogMessage, 256)
 		chanCloseMtx := &sync.Mutex{}
 		isChannelClosed := false
+		closeLogChan := func() {
+			chanCloseMtx.Lock()
+			defer chanCloseMtx.Unlock()
+			if !isChannelClosed {
+				close(logChan)
+				isChannelClosed = true
+			}
+		}
+		dropped := &atomic.Uint64{}
+		warnedOnce := &atomic.Bool{}
+		enqueue := func(msg LogMessage) bool {
+			chanCloseMtx.Lock()
+			defer chanCloseMtx.Unlock()
+			if isChannelClosed {
+				return false
+			}
+			select {
+			case logChan <- msg:
+			default:
+				dropped.Add(1)
+				if warnedOnce.CompareAndSwap(false, true) {
+					log.Warn().Str("process", processName).Msg("ws subscriber backpressured; dropping log lines")
+				}
+			}
+			return true
+		}
 		connector := pclog.NewConnector(
 			func(messages []string) {
 				for _, message := range messages {
@@ -63,13 +91,10 @@ func (api *PcApi) HandleLogsStream(c *gin.Context) {
 						Message:     message,
 						ProcessName: processName,
 					}
-					logChan <- msg
+					enqueue(msg)
 				}
 				if !follow {
-					chanCloseMtx.Lock()
-					defer chanCloseMtx.Unlock()
-					close(logChan)
-					isChannelClosed = true
+					closeLogChan()
 				}
 			},
 			func(message string) (n int, err error) {
@@ -77,23 +102,13 @@ func (api *PcApi) HandleLogsStream(c *gin.Context) {
 					Message:     message,
 					ProcessName: processName,
 				}
-				chanCloseMtx.Lock()
-				defer chanCloseMtx.Unlock()
-				if isChannelClosed {
+				if !enqueue(msg) {
 					return 0, nil
-				}
-				// Non-blocking send: if the subscriber's WriteJSON is stuck
-				// (e.g. TCP send buffer full because the client stopped
-				// reading), dropping the line here is far better than
-				// blocking the producer and deadlocking the buffer.
-				select {
-				case logChan <- msg:
-				default:
 				}
 				return len(message), nil
 			},
 			endOffset)
-		go api.handleLog(ws, processName, connector, logChan, done)
+		go api.handleLog(ws, processName, connector, logChan, done, wsWriteMtx, dropped, closeLogChan)
 
 		err = api.project.GetLogsAndSubscribe(processName, connector)
 		if err != nil {
@@ -104,7 +119,22 @@ func (api *PcApi) HandleLogsStream(c *gin.Context) {
 
 }
 
-func (api *PcApi) handleLog(ws *websocket.Conn, procName string, connector *pclog.Connector, logChan chan LogMessage, done chan struct{}) {
+func (api *PcApi) handleLog(
+	ws *websocket.Conn,
+	procName string,
+	connector *pclog.Connector,
+	logChan chan LogMessage,
+	done chan struct{},
+	wsWriteMtx *sync.Mutex,
+	dropped *atomic.Uint64,
+	closeLogChan func(),
+) {
+	defer func() {
+		if count := dropped.Load(); count > 0 {
+			log.Warn().Str("process", procName).Uint64("dropped", count).
+				Msg("ws subscriber disconnected after dropped lines")
+		}
+	}()
 	defer func(project app.IProject, name string, observer pclog.LogObserver) {
 		err := project.UnSubscribeLogger(name, observer)
 		if err != nil {
@@ -115,11 +145,15 @@ func (api *PcApi) handleLog(ws *websocket.Conn, procName string, connector *pclo
 	for {
 		select {
 		case msg, open := <-logChan:
-			// handleLog is the sole writer on this ws.Conn; no global
-			// mutex needed. Setting a write deadline guards against a
-			// half-dead peer whose TCP send buffer never drains.
+			if !open {
+				return
+			}
+			// Serialize writes per ws.Conn. Multiple process streams share the
+			// same connection when the request contains comma-separated names.
+			wsWriteMtx.Lock()
 			_ = ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
 			err := ws.WriteJSON(&msg)
+			wsWriteMtx.Unlock()
 			if err != nil {
 				if errors.Is(err, net.ErrClosed) {
 					return
@@ -127,12 +161,9 @@ func (api *PcApi) handleLog(ws *websocket.Conn, procName string, connector *pclo
 				log.Err(err).Msg("Failed to write to socket")
 				return
 			}
-			if !open {
-				return
-			}
 		case <-done:
 			log.Warn().Msg("Socket closed remotely")
-			close(logChan)
+			closeLogChan()
 			return
 		}
 

--- a/src/api/ws_api.go
+++ b/src/api/ws_api.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/f1bonacc1/process-compose/src/app"
 	"github.com/f1bonacc1/process-compose/src/pclog"
@@ -81,7 +82,14 @@ func (api *PcApi) HandleLogsStream(c *gin.Context) {
 				if isChannelClosed {
 					return 0, nil
 				}
-				logChan <- msg
+				// Non-blocking send: if the subscriber's WriteJSON is stuck
+				// (e.g. TCP send buffer full because the client stopped
+				// reading), dropping the line here is far better than
+				// blocking the producer and deadlocking the buffer.
+				select {
+				case logChan <- msg:
+				default:
+				}
 				return len(message), nil
 			},
 			endOffset)
@@ -107,9 +115,11 @@ func (api *PcApi) handleLog(ws *websocket.Conn, procName string, connector *pclo
 	for {
 		select {
 		case msg, open := <-logChan:
-			api.wsMtx.Lock()
+			// handleLog is the sole writer on this ws.Conn; no global
+			// mutex needed. Setting a write deadline guards against a
+			// half-dead peer whose TCP send buffer never drains.
+			_ = ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
 			err := ws.WriteJSON(&msg)
-			api.wsMtx.Unlock()
 			if err != nil {
 				if errors.Is(err, net.ErrClosed) {
 					return

--- a/src/pclog/process_log_buffer.go
+++ b/src/pclog/process_log_buffer.go
@@ -50,9 +50,16 @@ func (b *ProcessLogBuffer) Write(message string) {
 	}
 	b.mxBuf.Unlock()
 
+	// Snapshot observers under the lock, then fan out without holding it.
+	// Holding mxObs across observer.WriteString lets a slow/blocked observer
+	// stall every other Write and any new GetLogsAndSubscribe on this buffer.
 	b.mxObs.Lock()
-	defer b.mxObs.Unlock()
+	snapshot := make([]LogObserver, 0, len(b.observers))
 	for _, observer := range b.observers {
+		snapshot = append(snapshot, observer)
+	}
+	b.mxObs.Unlock()
+	for _, observer := range snapshot {
 		_, _ = observer.WriteString(message)
 	}
 }


### PR DESCRIPTION
## Symptom

After running for a while (especially with TUI `attach` viewing log of any process), `process logs <name>` and the TUI log panel hang forever for that process. New WS subscribers complete the `101 Switching Protocols` handshake but the server never sends a single frame. Only the REST endpoint `/process/logs/:name/:endOffset/:limit` continues to work. The only recovery is restarting `process-compose`, which kills every supervised process.

## Root cause

Three interacting issues form the deadlock:

1. **`ProcessLogBuffer.Write` holds `mxObs` across `observer.WriteString`**. If any single observer's `WriteString` blocks, every subsequent `Write` and every new `GetLogsAndSubscribe` on this buffer is stuck behind the same lock forever.
2. **`HandleLogsStream`'s `slHandler` does a blocking `logChan <- msg`**. The per-subscriber `logChan` has capacity 256. If `handleLog`'s `WriteJSON` is blocked (e.g. peer's TCP receive buffer is full because the client stopped reading), `logChan` fills, `slHandler` blocks, and then (1) kicks in.
3. **A process-global `api.wsMtx` guards every `ws.WriteJSON`** in both `handleLog` and `handleStateStream`. gorilla/websocket already enforces a single writer per `Conn` internally, so this mutex is redundant — but worse, it lets a write that's stuck on **one** ws connection block writes on **every other** ws connection in the process.

A half-dead follower client (TUI attach that lost focus, network blip, etc.) is enough to trip (3) → (2) → (1) and permanently wedge logs for the affected process.

## Fix

- `src/pclog/process_log_buffer.go` — `Write` now snapshots `b.observers` under `mxObs` and releases the lock before fanning out to `WriteString`. A slow observer can no longer stall other writes or new subscriptions.
- `src/api/ws_api.go` — `slHandler` switches to a non-blocking `select { case logChan <- msg: default: }`. Dropping a line for a back-pressured subscriber is far better than deadlocking the producer.
- `src/api/ws_api.go` + `src/api/state_ws_api.go` — drop the global `api.wsMtx` around `WriteJSON` (gorilla's `Conn` is already single-writer-safe) and add `ws.SetWriteDeadline(now + 10s)` so a half-dead peer is evicted within 10 s instead of holding resources forever.

## Reproduction

```yaml
# repro-pc.yaml
version: "0.5"
processes:
  noisy:
    command: "i=0; while true; do printf 'line-%06d %s\n' $i $(date +%s%N); i=$((i+1)); done"
    availability:
      restart: "no"
```

```bash
process-compose -f repro-pc.yaml --port 8089 up -t=false &

# A follower that completes the WS handshake and then stops reading.
python3 ws_slow.py 8089 noisy true 999 &
SLOW=$!; sleep 0.5; kill -STOP $SLOW   # freeze the consumer

sleep 30   # let server-side Send-Q saturate

# Before the fix this hangs forever; REST still works.
process-compose --port 8089 process logs --tail 3 noisy
curl http://127.0.0.1:8089/process/logs/noisy/0/3
```

`ws_slow.py` is a ~30 line script that performs the WS upgrade and then sleeps without reading. Happy to add it under `scripts/` or as a test if useful.

## Verification

| Step | Before | After |
|---|---|---|
| `Send-Q` to the frozen follower | rises to ~1.9 MB, then stays there indefinitely | rises to ~1.9 MB, then **the follower is evicted by the write deadline** (server fd count drops) |
| Second `process logs` after step above | hangs (timeout, 0 bytes) | **succeeds immediately** |
| `SIGCONT` on the slow client | does **not** recover | recovers immediately (was never broken once the deadline ticked) |
| REST `/process/logs/...` | works throughout | works throughout |

No new tests added in this PR — happy to add a regression test (slow ws consumer + assertion that a second `GetLogsAndSubscribe` returns within a deadline) if you'd like.
