### PR TITLE
Add ability to define namespaces via environment variable

### DIFF
--- a/crates/client/src/cli/cmd/flags.rs
+++ b/crates/client/src/cli/cmd/flags.rs
@@ -29,6 +29,7 @@ pub mod env {
     pub const PORT_NUM: &str = "PC_PORT_NUM";
     pub const DISABLE_TUI: &str = "PC_DISABLE_TUI";
     pub const CONFIG_FILES: &str = "PC_CONFIG_FILES";
+    pub const NAMESPACES: &str = "PC_NAMESPACES";
     pub const SHORTCUTS_FILES: &str = "PC_SHORTCUTS_FILES";
     pub const NO_SERVER: &str = "PC_NO_SERVER";
     pub const SOCKET_PATH: &str = "PC_SOCKET_PATH";

--- a/crates/client/src/cli/cmd/up.rs
+++ b/crates/client/src/cli/cmd/up.rs
@@ -59,8 +59,8 @@ pub struct ProcessComposeFlagsUp {
     #[builder(default = false)]
     pub logs_truncate: bool,
 
-    /// Run only specified namespaces (default: all)
-    #[arg(long = "namespace")]
+    /// Run only specified namespaces (default: all, env: PC_NAMESPACES)
+    #[arg(long = "namespace", env = env::NAMESPACES)]
     #[builder(default = Vec::new())]
     pub namespaces: Vec<String>,
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -136,7 +136,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(pcFlags.Address, "address", "", *pcFlags.Address, "address to listen on (env: "+config.EnvVarNameAddress+")")
 	rootCmd.Flags().StringArrayVarP(&opts.FileNames, "config", "f", config.GetConfigDefault(), "path to config files to load (env: "+config.EnvVarNameConfig+")")
 	rootCmd.Flags().StringArrayVarP(&opts.EnvFileNames, "env", "e", []string{".env"}, "path to env files to load")
-	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", nil, "run only specified namespaces (default all)")
+	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", config.GetNamespaceDefault(), "run only specified namespaces (default all, env: "+config.EnvVarNameNamespace+")")
 	rootCmd.PersistentFlags().StringVarP(pcFlags.LogFile, "log-file", "L", *pcFlags.LogFile, "Specify the log file path (env: "+config.LogPathEnvVarName+")")
 	rootCmd.PersistentFlags().BoolVar(pcFlags.IsReadOnlyMode, "read-only", *pcFlags.IsReadOnlyMode, "enable read-only mode (env: "+config.EnvVarReadOnlyMode+")")
 	rootCmd.Flags().BoolVar(pcFlags.DisableDotEnv, "disable-dotenv", *pcFlags.DisableDotEnv, "disable .env file loading (env: "+config.EnvVarDisableDotEnv+"=1)")

--- a/src/config/Flags.go
+++ b/src/config/Flags.go
@@ -35,6 +35,7 @@ const (
 	EnvVarNamePort             = "PC_PORT_NUM"
 	EnvVarNameTui              = "PC_DISABLE_TUI"
 	EnvVarNameConfig           = "PC_CONFIG_FILES"
+	EnvVarNameNamespace        = "PC_NAMESPACES"
 	EnvVarNameShortcuts        = "PC_SHORTCUTS_FILES"
 	EnvVarNameRecipes          = "PC_RECIPE_FILES"
 	EnvVarNameNoServer         = "PC_NO_SERVER"

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -206,6 +206,14 @@ func GetConfigDefault() []string {
 	return []string{}
 }
 
+func GetNamespaceDefault() []string {
+	val, found := os.LookupEnv(EnvVarNameNamespace)
+	if found {
+		return strings.Split(val, ",")
+	}
+	return []string{}
+}
+
 func CreateProcCompHome() string {
 	if env := os.Getenv(pcConfigEnv); env != "" {
 		return env

--- a/www/docs/cli/process-compose.md
+++ b/www/docs/cli/process-compose.md
@@ -23,7 +23,7 @@ process-compose [flags]
   -L, --log-file string          Specify the log file path (env: PC_LOG_FILE) (default "/tmp/process-compose-<user>.log")
       --log-no-color             disable color output in the log file (env: PC_LOG_NO_COLOR)
       --logs-truncate            truncate process logs buffer on startup
-  -n, --namespace stringArray    run only specified namespaces (default all)
+  -n, --namespace stringArray    run only specified namespaces (default all, env: PC_NAMESPACES)
       --no-server                disable HTTP server (env: PC_NO_SERVER)
       --ordered-shutdown         shut down processes in reverse dependency order
   -p, --port int                 port number (env: PC_PORT_NUM) (default 8080)
@@ -58,4 +58,3 @@ process-compose [flags]
 * [process-compose run](process-compose_run.md)	 - Run PROCESS in the foreground, and its dependencies in the background
 * [process-compose up](process-compose_up.md)	 - Run process compose project
 * [process-compose version](process-compose_version.md)	 - Print version and build info
-

--- a/www/docs/cli/process-compose_project_update.md
+++ b/www/docs/cli/process-compose_project_update.md
@@ -11,7 +11,7 @@ process-compose project update [flags]
 ```
   -f, --config stringArray      path to config files to load (env: PC_CONFIG_FILES)
   -h, --help                    help for update
-  -n, --namespace stringArray   run only specified namespaces (default all)
+  -n, --namespace stringArray   run only specified namespaces (default all, env: PC_NAMESPACES)
   -v, --verbose                 verbose output
 ```
 
@@ -33,4 +33,3 @@ process-compose project update [flags]
 ### SEE ALSO
 
 * [process-compose project](process-compose_project.md)	 - Execute operations on a running Process Compose project
-

--- a/www/docs/cli/process-compose_up.md
+++ b/www/docs/cli/process-compose_up.md
@@ -26,7 +26,7 @@ process-compose up [PROCESS...] [flags]
   -d, --hide-disabled            hide disabled processes (env: PC_HIDE_DISABLED_PROC)
       --keep-project             keep the project running even after all processes exit
       --logs-truncate            truncate process logs buffer on startup
-  -n, --namespace stringArray    run only specified namespaces (default all)
+  -n, --namespace stringArray    run only specified namespaces (default all, env: PC_NAMESPACES)
       --no-deps                  don't start dependent processes
       --recursive-metrics        collect metrics recursively (env: PC_RECURSIVE_METRICS)
   -r, --ref-rate duration        TUI refresh interval in seconds or as a Go duration string (e.g. 1s) (default 1)
@@ -56,4 +56,3 @@ process-compose up [PROCESS...] [flags]
 ### SEE ALSO
 
 * [process-compose](process-compose.md)	 - Processes scheduler and orchestrator
-


### PR DESCRIPTION
Allow to use comma separated list in environment variable `PC_NAMESPACES` as an alternative to `--namespace`/`-n`.

Fixes: https://github.com/F1bonacc1/process-compose/issues/491