### PR TITLE
feat(tui): copy-on-select, configurable copy key, clearer Select label

### DIFF
--- a/src/tui/actions.go
+++ b/src/tui/actions.go
@@ -20,6 +20,7 @@ const (
 	ActionFollowLog        = ActionName("log_follow")
 	ActionWrapLog          = ActionName("log_wrap")
 	ActionLogSelection     = ActionName("log_select")
+	ActionLogCopy          = ActionName("log_copy")
 	ActionProcessStart     = ActionName("process_start")
 	ActionProcessScale     = ActionName("process_scale")
 	ActionProcessInfo      = ActionName("process_info")
@@ -56,6 +57,7 @@ var defaultShortcuts = map[ActionName]tcell.Key{
 	ActionFollowLog:        tcell.KeyF5,
 	ActionWrapLog:          tcell.KeyF6,
 	ActionLogSelection:     tcell.KeyCtrlS,
+	ActionLogCopy:          tcell.KeyCR,
 	ActionProcessScale:     tcell.KeyF2,
 	ActionProcessInfo:      tcell.KeyF3,
 	ActionProcessSignal:    tcell.KeyCtrlX,
@@ -344,9 +346,12 @@ func newShortCuts() *ShortCuts {
 			},
 			ActionLogSelection: {
 				ToggleDescription: map[bool]string{
-					true:  "Select On",
-					false: "Select Off",
+					true:  "Enable Select",
+					false: "Disable Select",
 				},
+			},
+			ActionLogCopy: {
+				Description: "Copy Selection",
 			},
 			ActionLogPrettyPrint: {
 				ToggleDescription: map[bool]string{

--- a/src/tui/actions_test.go
+++ b/src/tui/actions_test.go
@@ -1,0 +1,65 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestDefaultLogCopyShortcut(t *testing.T) {
+	sc := newShortCuts()
+	action, found := sc.ShortCutKeys[ActionLogCopy]
+	if !found {
+		t.Fatalf("expected default shortcuts to contain %q", ActionLogCopy)
+	}
+	if action.key != tcell.KeyCR {
+		t.Errorf("expected default log_copy key to be Enter (KeyCR), got %v", action.key)
+	}
+	if action.rune != 0 {
+		t.Errorf("expected default log_copy rune to be unset, got %q", action.rune)
+	}
+	if action.ShortCut != tcell.KeyNames[tcell.KeyCR] {
+		t.Errorf("expected default log_copy label %q, got %q", tcell.KeyNames[tcell.KeyCR], action.ShortCut)
+	}
+}
+
+func TestLogCopyShortcutOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		shortcut string
+		wantKey  tcell.Key
+		wantRune rune
+	}{
+		{name: "rebind to a single rune (vim-style yank)", shortcut: "y", wantKey: 0, wantRune: 'y'},
+		{name: "rebind to a key combination", shortcut: "Ctrl-Y", wantKey: tcell.KeyCtrlY, wantRune: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "shortcuts.yaml")
+			yaml := "shortcuts:\n  log_copy:\n    shortcut: \"" + tt.shortcut + "\"\n"
+			if err := os.WriteFile(path, []byte(yaml), 0600); err != nil {
+				t.Fatalf("failed to write shortcuts file: %v", err)
+			}
+
+			sc := newShortCuts()
+			if err := sc.loadFromFile(path); err != nil {
+				t.Fatalf("loadFromFile failed: %v", err)
+			}
+
+			action := sc.ShortCutKeys[ActionLogCopy]
+			if action == nil {
+				t.Fatalf("log_copy action missing after override")
+			}
+			if action.key != tt.wantKey {
+				t.Errorf("expected key %v, got %v", tt.wantKey, action.key)
+			}
+			if action.rune != tt.wantRune {
+				t.Errorf("expected rune %q, got %q", tt.wantRune, action.rune)
+			}
+		})
+	}
+}

--- a/src/tui/log-operations.go
+++ b/src/tui/log-operations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/f1bonacc1/glippy"
 	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 	"github.com/rs/zerolog/log"
 )
 
@@ -17,7 +18,7 @@ func (pv *pcView) toggleLogSelection() {
 		row, col := pv.logsText.GetScrollOffset()
 		pv.logsTextArea.SetText(pv.logsText.GetText(true), false).
 			SetBorder(true).
-			SetTitle(name + " [Select & Press Enter to Copy]")
+			SetTitle(fmt.Sprintf("%s [Select to Copy (or press %s)]", name, pv.logCopyShortcut()))
 		pv.logsTextArea.SetOffset(row, col)
 	} else {
 		pv.logsTextArea.SetText("", false)
@@ -98,25 +99,72 @@ func (pv *pcView) updateLogs(ctx context.Context) {
 
 func (pv *pcView) createLogSelectionTextArea() {
 	pv.logsTextArea.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		switch event.Key() {
-		case tcell.KeyCR:
-			text, start, _ := pv.logsTextArea.GetSelection()
-			method, err := glippy.SetWithMethod(text)
-			if err != nil {
-				log.Err(err).Msg("failed to set clipboard")
-				pv.attentionMessage(fmt.Sprintf("Failed to copy to clipboard: %s", err.Error()), 5*time.Second, true)
-			} else if method == glippy.MethodOSC52 {
-				pv.attentionMessage("Copied via OSC 52 (terminal must allow OSC 52)", 3*time.Second, false)
-			} else {
-				pv.attentionMessage("Copied to clipboard", 2*time.Second, false)
-			}
-			pv.logsTextArea.Select(start, start)
-		case tcell.KeyEsc:
+		switch {
+		case pv.isLogCopyEvent(event):
+			pv.copyLogSelection(true)
+		case event.Key() == tcell.KeyEsc:
 			pv.toggleLogSelection()
 			pv.updateHelpTextView()
 		}
 		return nil
 	})
+
+	// Copy-on-select: completing a mouse selection (drag release) copies it to
+	// the clipboard automatically, no key press required. The capture runs
+	// before the text area's own handler, but the selection has already been
+	// extended by the preceding mouse-move events, so it is current here.
+	pv.logsTextArea.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		if pv.logSelect && action == tview.MouseLeftUp {
+			pv.copyLogSelection(false)
+		}
+		return action, event
+	})
+}
+
+// copyLogSelection copies the current text-area selection to the clipboard.
+// When collapse is true the selection is cleared afterwards (used by the
+// keyboard path); the mouse path keeps the highlight visible. Empty selections
+// are ignored so a stray click or key press never clobbers the clipboard.
+func (pv *pcView) copyLogSelection(collapse bool) {
+	text, start, _ := pv.logsTextArea.GetSelection()
+	if len(text) == 0 {
+		return
+	}
+	method, err := glippy.SetWithMethod(text)
+	if err != nil {
+		log.Err(err).Msg("failed to set clipboard")
+		pv.attentionMessage(fmt.Sprintf("Failed to copy to clipboard: %s", err.Error()), 5*time.Second, true)
+	} else if method == glippy.MethodOSC52 {
+		pv.attentionMessage("Copied via OSC 52 (terminal must allow OSC 52)", 3*time.Second, false)
+	} else {
+		pv.attentionMessage("Copied to clipboard", 2*time.Second, false)
+	}
+	if collapse {
+		pv.logsTextArea.Select(start, start)
+	}
+}
+
+// logCopyShortcut returns the human-readable label of the configured copy
+// shortcut (e.g. "Enter", "Ctrl-Y", "y"), falling back to "Enter".
+func (pv *pcView) logCopyShortcut() string {
+	if action := pv.shortcuts.ShortCutKeys[ActionLogCopy]; action != nil && action.ShortCut != "" {
+		return action.ShortCut
+	}
+	return tcell.KeyNames[tcell.KeyCR]
+}
+
+// isLogCopyEvent reports whether the given key event matches the configured
+// copy-selection shortcut. The shortcut may be bound to either a special key
+// (e.g. Enter, Ctrl-Y) or a single rune (e.g. y).
+func (pv *pcView) isLogCopyEvent(event *tcell.EventKey) bool {
+	action := pv.shortcuts.ShortCutKeys[ActionLogCopy]
+	if action == nil {
+		return event.Key() == tcell.KeyCR
+	}
+	if action.rune != 0 {
+		return event.Key() == tcell.KeyRune && event.Rune() == action.rune
+	}
+	return event.Key() == action.key
 }
 
 func (pv *pcView) getLogTitle(name string) string {

--- a/www/docs/tui.md
+++ b/www/docs/tui.md
@@ -47,6 +47,30 @@ processes:
 
 > :bulb: Too long log lines (above 2^16 bytes long) can cause the log collector to hang.
 
+## Copying Logs to the Clipboard
+
+Toggle **selection mode** with `Ctrl+S` (`Enable Select` in the footer). The log pane then becomes selectable and there are two ways to copy:
+
+- **Mouse:** drag to highlight — releasing the mouse copies the selection automatically (copy-on-select), no key press required.
+- **Keyboard:** highlight with `Shift`+arrows and press `Enter` to copy.
+
+Press `Esc` to leave selection mode.
+
+Process Compose copies through your system clipboard when available and falls back to the [OSC 52](https://www.reddit.com/r/vim/comments/k1ydpn/a_guide_on_how_to_copy_text_from_anywhere/) terminal escape sequence otherwise (your terminal must allow OSC 52). A status message confirms which method was used.
+
+The keyboard copy key is configurable via the `log_copy` shortcut — for example, rebind it to `y` for a Vim-style yank:
+
+```yaml
+# $XDG_CONFIG_HOME/process-compose/shortcuts.yaml
+shortcuts:
+  log_select:
+    shortcut: Ctrl-S # toggle selection mode
+  log_copy:
+    shortcut: Enter  # copy the current selection (default)
+```
+
+> :bulb: `Ctrl+C` cannot be used to copy because it is reserved for quitting Process Compose (and for forwarding `SIGINT` to a focused interactive process).
+
 ## Command Palette
 
 Press `:` to open the command palette — a searchable list of available actions. Type to filter, use arrow keys to navigate, and press `Enter` to select.


### PR DESCRIPTION
## What

Makes copying logs out of the TUI ergonomic and configurable:

1. **Copy-on-select (mouse):** releasing a mouse drag in selection mode copies the highlight to the clipboard automatically — no `Enter` needed.
2. **Configurable keyboard copy key:** new `log_copy` shortcut, default `Enter` (**fully backward compatible**), so it can be rebound — e.g. `y` for a Vim-style yank.
3. **Clearer footer label:** the selection toggle now reads `Enable Select` / `Disable Select` (the action) instead of `Select On` / `Select Off` (which read as current state).
4. **Docs:** new "Copying Logs to the Clipboard" section in `www/docs/tui.md`, including the OSC 52 fallback — previously undocumented.

```yaml
# $XDG_CONFIG_HOME/process-compose/shortcuts.yaml
shortcuts:
  log_copy:
    shortcut: y   # Vim-style yank instead of Enter
```

## Why

The copy key (`Enter`) and exit key (`Esc`) in selection mode were the only TUI bindings not covered by the configurable shortcuts system, and "turn Select on → highlight → nothing's in my clipboard until I press Enter" is a recurring point of confusion. `Ctrl+C` can't simply be adopted for copy because it's already the global quit binding (and forwards `SIGINT` to a focused interactive process), so copy-on-select plus a configurable copy key is the pragmatic fix.

## How

- **`src/tui/actions.go`** — new `ActionLogCopy` (`log_copy`), default `tcell.KeyCR` in `defaultShortcuts`, and a `ShortCutKeys` entry. Relabels `ActionLogSelection`'s `ToggleDescription`. `log_copy` is intentionally left out of the footer/help order arrays, so the footer layout is unchanged.
- **`src/tui/log-operations.go`** — copy logic extracted into `copyLogSelection(collapse bool)` (ignores empty selections so a stray click/press never clobbers the clipboard). The keyboard path matches the configured key via `isLogCopyEvent` (special key *or* rune); the title hint uses `logCopyShortcut`. A `SetMouseCapture` on the text area copies on `MouseLeftUp`. `Esc` still exits.
- **`src/tui/actions_test.go`** — unit tests for the default (`Enter`) and overrides (`y` rune, `Ctrl-Y` key).
- **`www/docs/tui.md`** — new docs section.

## Behavior notes

- Default keyboard behavior is unchanged: `Enter` still copies, `Esc` still exits.
- Copy-on-select fires only on a deliberate mouse drag release with a non-empty selection, in selection mode. If you'd prefer it gated behind a config flag, easy to add.
- The mouse path keeps the highlight visible after copying; the keyboard path collapses it (as before).

## Testing

- `go build ./...` — clean
- `go test ./...` — pass (incl. new tests)
- `gofmt -l` / `go vet ./src/tui/` — clean

Closes #509
