### PR TITLE
Add Solarized Light and Solarized Dark themes

### DIFF
--- a/src/config/themes/solarized-dark-theme.yaml
+++ b/src/config/themes/solarized-dark-theme.yaml
@@ -1,0 +1,36 @@
+style:
+  name: "Solarized Dark"
+  body:
+    fgColor: '#839496'          # base0
+    bgColor: '#002b36'          # base03
+    secondaryTextColor: '#b58900'  # yellow
+    tertiaryTextColor: '#2aa198'   # cyan
+    borderColor: '#586e75'      # base01
+  stat_table:
+    keyFgColor: '#b58900'       # yellow
+    valueFgColor: '#93a1a1'     # base1
+    logoColor: '#268bd2'        # blue
+  proc_table:
+    fgColor: '#268bd2'          # blue
+    fgWarning: '#cb4b16'        # orange
+    fgPending: '#586e75'        # base01
+    fgCompleted: '#859900'      # green
+    fgError: '#dc322f'          # red
+    headerFgColor: '#b58900'    # yellow
+  help:
+    fgColor: '#93a1a1'          # base1
+    keyColor: '#b58900'         # yellow
+    hlColor: '#073642'          # base02
+    categoryFgColor: '#6c71c4'  # violet
+  dialog:
+    fgColor: '#93a1a1'          # base1
+    bgColor: '#073642'          # base02
+    contrastBgColor: '#268bd2'  # blue
+    attentionBgColor: '#dc322f' # red
+    buttonFgColor: '#002b36'    # base03
+    buttonBgColor: '#2aa198'    # cyan
+    buttonFocusFgColor: '#002b36'
+    buttonFocusBgColor: '#268bd2'  # blue
+    labelFgColor: '#b58900'     # yellow
+    fieldFgColor: '#93a1a1'     # base1
+    fieldBgColor: '#073642'     # base02

--- a/src/config/themes/solarized-light-theme.yaml
+++ b/src/config/themes/solarized-light-theme.yaml
@@ -1,0 +1,36 @@
+style:
+  name: "Solarized Light"
+  body:
+    fgColor: '#657b83'          # base00
+    bgColor: '#fdf6e3'          # base3
+    secondaryTextColor: '#b58900'  # yellow
+    tertiaryTextColor: '#2aa198'   # cyan
+    borderColor: '#93a1a1'      # base1
+  stat_table:
+    keyFgColor: '#b58900'       # yellow
+    valueFgColor: '#586e75'     # base01
+    logoColor: '#268bd2'        # blue
+  proc_table:
+    fgColor: '#268bd2'          # blue
+    fgWarning: '#cb4b16'        # orange
+    fgPending: '#93a1a1'        # base1
+    fgCompleted: '#859900'      # green
+    fgError: '#dc322f'          # red
+    headerFgColor: '#b58900'    # yellow
+  help:
+    fgColor: '#657b83'          # base00
+    keyColor: '#b58900'         # yellow
+    hlColor: '#eee8d5'          # base2
+    categoryFgColor: '#6c71c4'  # violet
+  dialog:
+    fgColor: '#586e75'          # base01
+    bgColor: '#eee8d5'          # base2
+    contrastBgColor: '#268bd2'  # blue
+    attentionBgColor: '#dc322f' # red
+    buttonFgColor: '#fdf6e3'    # base3
+    buttonBgColor: '#268bd2'    # blue
+    buttonFocusFgColor: '#fdf6e3'
+    buttonFocusBgColor: '#2aa198'  # cyan
+    labelFgColor: '#b58900'     # yellow
+    fieldFgColor: '#586e75'     # base01
+    fieldBgColor: '#eee8d5'     # base2


### PR DESCRIPTION
## What

Adds two built-in TUI themes based on the [Solarized](https://ethanschoonover.com/solarized/) palette by Ethan Schoonover — a light and a dark variant:

- `src/config/themes/solarized-light-theme.yaml` — "Solarized Light"
- `src/config/themes/solarized-dark-theme.yaml` — "Solarized Dark"

Solarized is a widely-used, precisely-specified palette (both variants share the same accent colors on inverted backgrounds), so shipping the pair felt natural. Both themes are picked up automatically via the existing `//go:embed themes/*-theme.yaml` + `ReadDir` discovery — no other code changes required.

## Palette mapping

Accents follow the canonical Solarized roles:

| role | color |
|------|-------|
| accent (keys / headers / logo) | yellow `#b58900`, blue `#268bd2` |
| completed | green `#859900` |
| warning | orange `#cb4b16` |
| error | red `#dc322f` |
| category | violet `#6c71c4` |

Light uses `base3 #fdf6e3` background / `base00 #657b83` text; dark uses `base03 #002b36` / `base0 #839496`.

## Testing

Selected each theme via `CTRL-T` and confirmed correct rendering of the stat table, process table (all states), help footer, and dialogs in a truecolor terminal.
