### PR TITLE
docs(logging): clarify PC_LOG_FILE truncation between server and client commands

### DIFF
--- a/www/docs/logging.md
+++ b/www/docs/logging.md
@@ -84,6 +84,31 @@ log_configuration:
 
 Default log location: `/tmp/process-compose-$USER.log`
 
+### Client Commands and `PC_LOG_FILE`
+
+Client commands (`down`, `attach`, `list`, `process`, `project`, `namespace`) write to
+their own log file so they don't overwrite the log of a running `process-compose`
+server. By default that's `/tmp/process-compose-$USER-client.log`, next to the
+server's `/tmp/process-compose-$USER.log`.
+
+`PC_LOG_FILE` (and `--log-file`) sets the path for every `process-compose`
+invocation, server and client alike. Since each invocation truncates its log file
+on open, exporting `PC_LOG_FILE` in your shell points both at the same file, and
+the next client command starts it over.
+
+To use custom locations, give the server and the clients separate paths:
+
+```shell
+process-compose up --detached --log-file .pc/logs/process-compose.log
+
+export PC_LOG_FILE=.pc/logs/process-compose-client.log
+process-compose list
+```
+
+The explicit `--log-file` on `up` takes precedence over `PC_LOG_FILE`, so the
+server keeps `process-compose.log` while client commands log to
+`process-compose-client.log`.
+
 By default, the internal log file contains ANSI color codes. You can disable color output using the `--log-no-color` flag or the `PC_LOG_NO_COLOR` environment variable.
 
 ```bash
@@ -103,21 +128,3 @@ processes:
 ```
 
 This will allow you to spot any issues with the processes execution, without leaving the `process-compose` TUI.
-
-### Client commands and `PC_LOG_FILE`
-
-`PC_LOG_FILE` (or `--log-file`) sets the log path for whatever `process-compose`
-command you're running, server or client. If you export it globally in your
-shell, a client command like `list` or `attach` will open and truncate the
-same file your detached server is writing to, wiping out whatever was logged
-so far.
-
-Keep the two paths separate if you're doing both in the same shell:
-
-```shell
-process-compose up --detached --log-file .pc/logs/process-compose.log
-
-PC_LOG_FILE=.pc/logs/process-compose-client.log process-compose list
-```
-
-Background: [#318](https://github.com/F1bonacc1/process-compose/issues/318)

--- a/www/docs/logging.md
+++ b/www/docs/logging.md
@@ -103,3 +103,21 @@ processes:
 ```
 
 This will allow you to spot any issues with the processes execution, without leaving the `process-compose` TUI.
+
+### Client commands and `PC_LOG_FILE`
+
+`PC_LOG_FILE` (or `--log-file`) sets the log path for whatever `process-compose`
+command you're running, server or client. If you export it globally in your
+shell, a client command like `list` or `attach` will open and truncate the
+same file your detached server is writing to, wiping out whatever was logged
+so far.
+
+Keep the two paths separate if you're doing both in the same shell:
+
+```shell
+process-compose up --detached --log-file .pc/logs/process-compose.log
+
+PC_LOG_FILE=.pc/logs/process-compose-client.log process-compose list
+```
+
+Background: [#318](https://github.com/F1bonacc1/process-compose/issues/318)


### PR DESCRIPTION
Small docs addition to `www/docs/logging.md` clarifying that `PC_LOG_FILE` (or `--log-file`) is shared between the server process and client commands, and that client commands will truncate the file on open if it's the same path the server is using.

Related to #318. Keeping this to docs only for now, will follow up on the issue with some thoughts on the actual fix.

Didn't run the full `make ci` since this only touches a markdown file and `build-nix` isn't available in my environment (no Nix installed), so there's nothing Go-related for it to catch here.