### PR TITLE
feat: -n/--namespace prune the dependency graph

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -137,6 +137,7 @@ func init() {
 	rootCmd.Flags().StringArrayVarP(&opts.FileNames, "config", "f", config.GetConfigDefault(), "path to config files to load (env: "+config.EnvVarNameConfig+")")
 	rootCmd.Flags().StringArrayVarP(&opts.EnvFileNames, "env", "e", []string{".env"}, "path to env files to load")
 	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", config.GetNamespaceDefault(), "run only specified namespaces (default all, env: "+config.EnvVarNameNamespace+")")
+	rootCmd.Flags().BoolVar(&opts.StrictNamespace, "strict-namespace", config.GetStrictNamespaceDefault(), "fail if a scoped process depends on a process outside the selected namespaces instead of pruning it (env: "+config.EnvVarStrictNamespace+")")
 	rootCmd.PersistentFlags().StringVarP(pcFlags.LogFile, "log-file", "L", *pcFlags.LogFile, "Specify the log file path (env: "+config.LogPathEnvVarName+")")
 	rootCmd.PersistentFlags().BoolVar(pcFlags.IsReadOnlyMode, "read-only", *pcFlags.IsReadOnlyMode, "enable read-only mode (env: "+config.EnvVarReadOnlyMode+")")
 	rootCmd.Flags().BoolVar(pcFlags.DisableDotEnv, "disable-dotenv", *pcFlags.DisableDotEnv, "disable .env file loading (env: "+config.EnvVarDisableDotEnv+"=1)")

--- a/src/cmd/up.go
+++ b/src/cmd/up.go
@@ -27,6 +27,7 @@ func init() {
 
 	upCmd.Flags().BoolVarP(pcFlags.NoDependencies, "no-deps", "", *pcFlags.NoDependencies, "don't start dependent processes")
 	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("namespace"))
+	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("strict-namespace"))
 	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("config"))
 	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("env"))
 	upCmd.Flags().AddFlag(rootCmd.Flags().Lookup("ref-rate"))

--- a/src/config/Flags.go
+++ b/src/config/Flags.go
@@ -36,6 +36,7 @@ const (
 	EnvVarNameTui              = "PC_DISABLE_TUI"
 	EnvVarNameConfig           = "PC_CONFIG_FILES"
 	EnvVarNameNamespace        = "PC_NAMESPACES"
+	EnvVarStrictNamespace      = "PC_STRICT_NAMESPACE"
 	EnvVarNameShortcuts        = "PC_SHORTCUTS_FILES"
 	EnvVarNameRecipes          = "PC_RECIPE_FILES"
 	EnvVarNameNoServer         = "PC_NO_SERVER"

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -215,6 +215,11 @@ func GetNamespaceDefault() []string {
 	return []string{}
 }
 
+func GetStrictNamespaceDefault() bool {
+	val, found := os.LookupEnv(EnvVarStrictNamespace)
+	return found && val != "" && strings.ToLower(val) != "false"
+}
+
 func CreateProcCompHome() string {
 	if env := os.Getenv(pcConfigEnv); env != "" {
 		return env

--- a/src/loader/admit_test.go
+++ b/src/loader/admit_test.go
@@ -1,0 +1,125 @@
+package loader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/f1bonacc1/process-compose/src/admitter"
+	"github.com/f1bonacc1/process-compose/src/types"
+)
+
+func newNamespaceProject() *types.Project {
+	return &types.Project{
+		Processes: types.Processes{
+			"foo": {
+				Name:        "foo",
+				ReplicaName: "foo",
+				Namespace:   "foo",
+				DependsOn: types.DependsOnConfig{
+					"bar": {Condition: types.ProcessConditionCompletedSuccessfully},
+				},
+			},
+			"bar": {
+				Name:        "bar",
+				ReplicaName: "bar",
+				Namespace:   "bar",
+			},
+		},
+	}
+}
+
+func TestAdmitProcesses_PrunesDependencyOnRemovedProcess(t *testing.T) {
+	p := newNamespaceProject()
+	opts := &LoaderOptions{}
+	opts.AddAdmitter(&admitter.NamespaceAdmitter{EnabledNamespaces: []string{"foo"}})
+
+	if _, err := admitProcesses(opts, p); err != nil {
+		t.Fatalf("admitProcesses() unexpected error: %v", err)
+	}
+
+	if _, ok := p.Processes["bar"]; ok {
+		t.Fatalf("process 'bar' should have been pruned by the namespace admitter")
+	}
+	foo, ok := p.Processes["foo"]
+	if !ok {
+		t.Fatalf("process 'foo' should have been retained")
+	}
+	if _, ok := foo.DependsOn["bar"]; ok {
+		t.Errorf("dangling dependency 'bar' should have been pruned from 'foo', got %v", foo.DependsOn)
+	}
+}
+
+func TestAdmitProcesses_KeepsIntraNamespaceDependency(t *testing.T) {
+	p := &types.Project{
+		Processes: types.Processes{
+			"foo": {
+				Name:        "foo",
+				ReplicaName: "foo",
+				Namespace:   "web",
+				DependsOn: types.DependsOnConfig{
+					"bar": {Condition: types.ProcessConditionCompletedSuccessfully},
+				},
+			},
+			"bar": {
+				Name:        "bar",
+				ReplicaName: "bar",
+				Namespace:   "web",
+			},
+		},
+	}
+	opts := &LoaderOptions{}
+	opts.AddAdmitter(&admitter.NamespaceAdmitter{EnabledNamespaces: []string{"web"}})
+
+	if _, err := admitProcesses(opts, p); err != nil {
+		t.Fatalf("admitProcesses() unexpected error: %v", err)
+	}
+
+	foo := p.Processes["foo"]
+	if _, ok := foo.DependsOn["bar"]; !ok {
+		t.Errorf("intra-namespace dependency 'bar' should be preserved on 'foo', got %v", foo.DependsOn)
+	}
+}
+
+func TestAdmitProcesses_StrictNamespaceErrorsOnUnsatisfiableDependency(t *testing.T) {
+	p := newNamespaceProject()
+	opts := &LoaderOptions{StrictNamespace: true}
+	opts.AddAdmitter(&admitter.NamespaceAdmitter{EnabledNamespaces: []string{"foo"}})
+
+	_, err := admitProcesses(opts, p)
+	if err == nil {
+		t.Fatalf("admitProcesses() expected an error in strict-namespace mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "'foo' -> 'bar'") {
+		t.Errorf("error should describe the unsatisfiable dependency, got: %v", err)
+	}
+	// The dependency must be left intact so the failure is not silently masked.
+	if _, ok := p.Processes["foo"].DependsOn["bar"]; !ok {
+		t.Errorf("strict mode must not prune the dependency")
+	}
+}
+
+func TestAdmitProcesses_StrictNamespacePassesWhenSatisfiable(t *testing.T) {
+	p := &types.Project{
+		Processes: types.Processes{
+			"foo": {
+				Name:        "foo",
+				ReplicaName: "foo",
+				Namespace:   "web",
+				DependsOn: types.DependsOnConfig{
+					"bar": {Condition: types.ProcessConditionCompletedSuccessfully},
+				},
+			},
+			"bar": {
+				Name:        "bar",
+				ReplicaName: "bar",
+				Namespace:   "web",
+			},
+		},
+	}
+	opts := &LoaderOptions{StrictNamespace: true}
+	opts.AddAdmitter(&admitter.NamespaceAdmitter{EnabledNamespaces: []string{"web"}})
+
+	if _, err := admitProcesses(opts, p); err != nil {
+		t.Fatalf("admitProcesses() should not error when deps stay within scope: %v", err)
+	}
+}

--- a/src/loader/loader.go
+++ b/src/loader/loader.go
@@ -103,7 +103,9 @@ func Load(opts *LoaderOptions) (*types.Project, error) {
 		validateMCPConfig,
 		validateProject,
 	)
-	admitProcesses(opts, mergedProject)
+	if _, admitErr := admitProcesses(opts, mergedProject); admitErr != nil {
+		return mergedProject, admitErr
+	}
 	return mergedProject, err
 }
 
@@ -132,9 +134,9 @@ func loadExtendProject(p *types.Project, opts *LoaderOptions, file string, index
 	return nil
 }
 
-func admitProcesses(opts *LoaderOptions, p *types.Project) *types.Project {
+func admitProcesses(opts *LoaderOptions, p *types.Project) (*types.Project, error) {
 	if opts.admitters == nil {
-		return p
+		return p, nil
 	}
 	for _, process := range p.Processes {
 		for _, adm := range opts.admitters {
@@ -144,7 +146,40 @@ func admitProcesses(opts *LoaderOptions, p *types.Project) *types.Project {
 			}
 		}
 	}
-	return p
+	if err := pruneDanglingDependencies(opts, p); err != nil {
+		return p, err
+	}
+	return p, nil
+}
+
+// pruneDanglingDependencies handles depends_on entries that reference processes
+// which are no longer part of the project (e.g. because they were pruned by an
+// admission policy such as namespace scoping). Without this, a retained process
+// would wait forever for a dependency that will never start.
+//
+// In strict mode it instead returns an error describing every unsatisfiable
+// dependency, so that scoping the project (e.g. to a namespace) fails loudly
+// rather than silently dropping cross-scope dependencies.
+func pruneDanglingDependencies(opts *LoaderOptions, p *types.Project) error {
+	var unsatisfied []string
+	for name, process := range p.Processes {
+		for depName := range process.DependsOn {
+			if _, ok := p.Processes[depName]; ok {
+				continue
+			}
+			if opts.StrictNamespace {
+				unsatisfied = append(unsatisfied, fmt.Sprintf("'%s' -> '%s'", name, depName))
+				continue
+			}
+			log.Info().Msgf("Dependency '%s' of process '%s' was pruned because it is not part of the project", depName, name)
+			delete(process.DependsOn, depName)
+		}
+	}
+	if len(unsatisfied) > 0 {
+		slices.Sort(unsatisfied)
+		return fmt.Errorf("unsatisfiable dependencies after scoping the project: %s", strings.Join(unsatisfied, ", "))
+	}
+	return nil
 }
 
 func loadProjectFromFile(inputFile string, opts *LoaderOptions) (*types.Project, error) {

--- a/src/loader/loader_options.go
+++ b/src/loader/loader_options.go
@@ -18,6 +18,7 @@ type LoaderOptions struct {
 	isTuiDisabled     bool
 	DryRun            bool
 	isOrderedShutdown bool
+	StrictNamespace   bool
 }
 
 func (o *LoaderOptions) AddAdmitter(adm ...admitter.Admitter) {

--- a/www/docs/cli/process-compose.md
+++ b/www/docs/cli/process-compose.md
@@ -34,6 +34,7 @@ process-compose [flags]
       --shortcuts stringArray    paths to shortcut config files to load (env: PC_SHORTCUTS_FILES) (default [/home/<user>/.config/process-compose/shortcuts.yml])
       --slow-ref-rate duration   Slow(er) refresh interval for resources (CPU, RAM) in seconds or as a Go duration string (e.g. 1s). The value should be higher than --ref-rate (default 1)
   -S, --sort string              sort column name. legal values (case insensitive): [AGE, CPU, EXIT, HEALTH, MEM, NAME, NAMESPACE, PID, RESTARTS, STATUS] (default "NAME")
+      --strict-namespace         fail if a scoped process depends on a process outside the selected namespaces instead of pruning it (env: PC_STRICT_NAMESPACE)
       --theme string             select process compose theme (default "Default")
       --token-file string        path to a file containing the API token (env: PC_API_TOKEN_PATH)
   -t, --tui                      enable TUI (disable with -t=false) (env: PC_DISABLE_TUI) (default true)

--- a/www/docs/cli/process-compose_up.md
+++ b/www/docs/cli/process-compose_up.md
@@ -34,6 +34,7 @@ process-compose up [PROCESS...] [flags]
       --shortcuts stringArray    paths to shortcut config files to load (env: PC_SHORTCUTS_FILES) (default [/home/<user>/.config/process-compose/shortcuts.yml])
       --slow-ref-rate duration   Slow(er) refresh interval for resources (CPU, RAM) in seconds or as a Go duration string (e.g. 1s). The value should be higher than --ref-rate (default 1)
   -S, --sort string              sort column name. legal values (case insensitive): [AGE, CPU, EXIT, HEALTH, MEM, NAME, NAMESPACE, PID, RESTARTS, STATUS] (default "NAME")
+      --strict-namespace         fail if a scoped process depends on a process outside the selected namespaces instead of pruning it (env: PC_STRICT_NAMESPACE)
       --theme string             select process compose theme (default "Default")
   -t, --tui                      enable TUI (disable with -t=false) (env: PC_DISABLE_TUI) (default true)
 ```

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -491,6 +491,15 @@ process-compose -n ns1 -n ns3
 # will start only ns1 and ns3. ns2 namespace won't run and won't be visible in the TUI
 ```
 
+When scoping to a subset of namespaces, any `depends_on` entry that points to a process outside the selected namespaces is automatically pruned. This lets you start just part of the stack (for example, when its dependencies are already running elsewhere) without the selected processes hanging on dependencies that will never start. Dependencies *within* the selected namespaces are still honored, so intra-namespace startup ordering is preserved.
+
+If you would rather fail fast than silently drop a cross-namespace dependency, add `--strict-namespace` (env: `PC_STRICT_NAMESPACE`). Instead of pruning, `process-compose` will exit with an error describing every dependency that cannot be satisfied by the selected namespaces:
+
+```shell
+process-compose -n ns1 --strict-namespace
+# errors if any process in ns1 depends on a process outside ns1
+```
+
 ### Namespace Operations
 
 You can perform bulk operations on namespaces using the CLI or TUI.


### PR DESCRIPTION
As per https://github.com/F1bonacc1/process-compose/issues/517 this PR implements two changes:

1. it modifies the existing behavior of `--namespace` so that dangling `depends_on` statements are pruned while retaining dependency relationships within the namespace.
2. it adds `--strict-namespace` for users who wish to error rather than allowing namespaces to prune unsatisfiable dependencies. This is strictly an improvement over the current functionality which hangs forever.

It's been tested both in unit tests and manually using the example config from https://github.com/F1bonacc1/process-compose/issues/517

```yaml
version: "0.5"

processes:
  foo:
    command: "echo 'foo'"
    namespace: "foo"
    depends_on:
      bar:
        condition: process_completed_successfully

  bar:
    command: "echo 'bar'"
    namespace: "bar"
```

for example

```sh
# starts and executes both processes in order
process-compose --no-server --keep-project

# starts and executes process bar
process-compose --no-server --keep-project --namespace bar

# starts and executes process bar
process-compose --no-server --keep-project --namespace bar --strict-namespace

# starts and executes process foo
process-compose --no-server --keep-project --namespace foo

# fails to start with a dependency error on foo --> bar
process-compose --no-server --keep-project --namespace foo --strict-namespace
```