### PR TITLE
🐛 Wait for process group extinction during shutdown

### DIFF
--- a/src/app/process.go
+++ b/src/app/process.go
@@ -477,21 +477,35 @@ func (p *Process) stopProcess(withNoRestart bool) error {
 }
 
 func (p *Process) forceKillOnTimeout() error {
-	p.mtxStopFn.Lock()
-	p.waitForStoppedCtx, p.waitForStoppedFn = context.WithTimeout(context.Background(), time.Duration(p.procConf.ShutDownParams.ShutDownTimeout)*time.Second)
-	p.mtxStopFn.Unlock()
-	<-p.waitForStoppedCtx.Done()
-	err := p.waitForStoppedCtx.Err()
-	switch {
-	case errors.Is(err, context.Canceled):
+	timeout := time.Duration(p.procConf.ShutDownParams.ShutDownTimeout) * time.Second
+	if p.waitForCommandExit(timeout, p.procConf.ShutDownParams.ParentOnly) {
 		return nil
-	case errors.Is(err, context.DeadlineExceeded):
-		log.Debug().Msgf("process failed to shut down within %d seconds, sending %d", p.procConf.ShutDownParams.ShutDownTimeout, syscall.SIGKILL)
-		return p.command.Stop(int(syscall.SIGKILL), false)
-	default:
-		log.Error().Err(err).Msgf("terminating %s with timeout %d failed", p.getName(), p.procConf.ShutDownParams.ShutDownTimeout)
+	}
+
+	log.Debug().Msgf("process failed to shut down within %d seconds, sending %d", p.procConf.ShutDownParams.ShutDownTimeout, syscall.SIGKILL)
+	if err := p.command.Stop(int(syscall.SIGKILL), false); err != nil {
 		return err
 	}
+	if p.waitForCommandExit(timeout, false) {
+		return nil
+	}
+	return fmt.Errorf("process group for %s is still running after SIGKILL", p.getName())
+}
+
+func (p *Process) waitForCommandExit(timeout time.Duration, parentOnly bool) bool {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	poll := time.NewTicker(20 * time.Millisecond)
+	defer poll.Stop()
+
+	for p.command.IsAlive(parentOnly) {
+		select {
+		case <-deadline.C:
+			return !p.command.IsAlive(parentOnly)
+		case <-poll.C:
+		}
+	}
+	return true
 }
 
 func (p *Process) doConfiguredStop(params types.ShutDownParams) error {

--- a/src/app/system_test.go
+++ b/src/app/system_test.go
@@ -1216,6 +1216,65 @@ func TestSystem_TestProcShutDownWithConfiguredTimeOut(t *testing.T) {
 
 }
 
+func TestSystem_ShutdownWaitsForProcessGroupExtinction(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test requires Unix process-group semantics")
+	}
+
+	const processName = "leader_exits_first"
+	childPIDFile := filepath.Join(t.TempDir(), "child.pid")
+	shell := command.DefaultShellConfig()
+	project := &types.Project{
+		Processes: map[string]types.ProcessConfig{
+			processName: {
+				Name:        processName,
+				ReplicaName: processName,
+				Executable:  shell.ShellCommand,
+				Args: []string{
+					shell.ShellArgument,
+					fmt.Sprintf("trap 'exit 0' TERM; bash -c \"trap '' TERM; while true; do sleep 1; done\" & echo $! > %q; wait", childPIDFile),
+				},
+				RestartPolicy: types.RestartPolicyConfig{Restart: types.RestartPolicyNo},
+				ShutDownParams: types.ShutDownParams{
+					ShutDownTimeout: 1,
+					Signal:          int(syscall.SIGTERM),
+				},
+			},
+		},
+		ShellConfig: shell,
+	}
+
+	runner, err := NewProjectRunner(&ProjectOpts{project: project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = runner.Run() }()
+
+	var childPID int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		raw, readErr := os.ReadFile(childPIDFile)
+		if readErr == nil {
+			parsed, _ := fmt.Sscanf(string(raw), "%d", &childPID)
+			if parsed == 1 {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if childPID <= 1 {
+		t.Fatal("child process never started")
+	}
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+
+	if err := runner.StopProcess(processName); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Kill(childPID, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("child process %d survived shutdown", childPID)
+	}
+}
+
 func TestSystem_TestRestartingProcessShutDown(t *testing.T) {
 	proc1 := "proc1"
 	shell := command.DefaultShellConfig()

--- a/src/command/command_wrapper.go
+++ b/src/command/command_wrapper.go
@@ -4,10 +4,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync/atomic"
 )
 
 type CmdWrapper struct {
-	cmd *exec.Cmd
+	cmd            *exec.Cmd
+	processGroupID atomic.Int64
 }
 
 func (c *CmdWrapper) GetPty() *os.File {
@@ -15,7 +17,11 @@ func (c *CmdWrapper) GetPty() *os.File {
 }
 
 func (c *CmdWrapper) Start() error {
-	return c.cmd.Start()
+	if err := c.cmd.Start(); err != nil {
+		return err
+	}
+	c.captureProcessGroup()
+	return nil
 }
 
 func (c *CmdWrapper) Run() error {

--- a/src/command/command_wrapper_pty.go
+++ b/src/command/command_wrapper_pty.go
@@ -27,6 +27,7 @@ func (c *CmdWrapperPty) Start() (err error) {
 	if err != nil {
 		return fmt.Errorf("error starting PTY command: %w", err)
 	}
+	c.captureProcessGroup()
 
 	// Set initial window size to a reasonable default
 	// This prevents programs like 'top' from rendering with tiny/wrong dimensions

--- a/src/command/commander.go
+++ b/src/command/commander.go
@@ -7,6 +7,7 @@ import (
 
 type Commander interface {
 	Stop(sig int, _parentOnly bool) error
+	IsAlive(parentOnly bool) bool
 	SetCmdArgs()
 	Start() error
 	Run() error

--- a/src/command/mock_command.go
+++ b/src/command/mock_command.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"io"
+	"sync/atomic"
 )
 
 type MockCommand struct {
@@ -10,6 +11,7 @@ type MockCommand struct {
 	env            []string
 	cancel         context.CancelFunc
 	stopChan       chan struct{}
+	isAlive        atomic.Bool
 	infoNoiseMaker *noiseMaker
 	errNoiseMaker  *noiseMaker
 }
@@ -25,6 +27,7 @@ func NewMockCommand() *MockCommand {
 func (c *MockCommand) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
+	c.isAlive.Store(true)
 	go c.infoNoiseMaker.Run(ctx)
 	return nil
 }
@@ -32,7 +35,12 @@ func (c *MockCommand) Start() error {
 func (c *MockCommand) Stop(_ int, _ bool) error {
 	c.stopChan <- struct{}{}
 	c.cancel()
+	c.isAlive.Store(false)
 	return nil
+}
+
+func (c *MockCommand) IsAlive(_ bool) bool {
+	return c.isAlive.Load()
 }
 
 func (c *MockCommand) SetCmdArgs() {

--- a/src/command/stopper_unix.go
+++ b/src/command/stopper_unix.go
@@ -3,8 +3,10 @@
 package command
 
 import (
-	"github.com/rs/zerolog/log"
+	"errors"
 	"syscall"
+
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -31,12 +33,40 @@ func (c *CmdWrapper) Stop(sig int, parentOnly bool) error {
 		return c.cmd.Process.Signal(syscall.Signal(sig))
 	}
 
-	pgid, err := syscall.Getpgid(c.Pid())
-	if err == nil {
-		return syscall.Kill(-pgid, syscall.Signal(sig))
+	pgid := int(c.processGroupID.Load())
+	if pgid <= 0 {
+		var err error
+		pgid, err = syscall.Getpgid(c.Pid())
+		if err != nil {
+			return err
+		}
+		c.processGroupID.CompareAndSwap(0, int64(pgid))
+	}
+	return syscall.Kill(-pgid, syscall.Signal(sig))
+}
+
+func (c *CmdWrapper) IsAlive(parentOnly bool) bool {
+	if c.cmd == nil || c.cmd.Process == nil {
+		return false
+	}
+	if parentOnly {
+		err := c.cmd.Process.Signal(syscall.Signal(0))
+		return err == nil || errors.Is(err, syscall.EPERM)
 	}
 
-	return err
+	pgid := int(c.processGroupID.Load())
+	if pgid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pgid, syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func (c *CmdWrapper) captureProcessGroup() {
+	pgid, err := syscall.Getpgid(c.Pid())
+	if err == nil {
+		c.processGroupID.Store(int64(pgid))
+	}
 }
 
 func (c *CmdWrapper) SetCmdArgs() {

--- a/src/command/stopper_windows.go
+++ b/src/command/stopper_windows.go
@@ -35,6 +35,12 @@ func (c *CmdWrapper) Stop(sig int, parentOnly bool) error {
 	return nil
 }
 
+func (c *CmdWrapper) IsAlive(_ bool) bool {
+	return c.cmd != nil && c.cmd.ProcessState == nil
+}
+
+func (c *CmdWrapper) captureProcessGroup() {}
+
 func (c *CmdWrapper) SetCmdArgs() {
 	//empty for windows
 }

--- a/src/command/stopper_windows.go
+++ b/src/command/stopper_windows.go
@@ -39,7 +39,9 @@ func (c *CmdWrapper) IsAlive(_ bool) bool {
 	return c.cmd != nil && c.cmd.ProcessState == nil
 }
 
-func (c *CmdWrapper) captureProcessGroup() {}
+func (c *CmdWrapper) captureProcessGroup() {
+	// Windows shutdown targets the live PID's process tree, so no group ID is retained.
+}
 
 func (c *CmdWrapper) SetCmdArgs() {
 	//empty for windows


### PR DESCRIPTION
## Why

Shutdown currently tracks the leader process rather than the process group it launched. If that leader exits on SIGTERM while a same-group child ignores the signal, the timeout is cancelled, `down` reports success, and the child remains alive.

## What changed

The command wrapper now retains the process group ID at launch and exposes group-aware liveness. Shutdown waits on the configured target—parent only or the full group—before deciding whether escalation is required. After SIGKILL, it also waits for the group to disappear instead of returning immediately.

A Unix regression starts a leader which exits cleanly on SIGTERM and a same-group child which ignores it, then proves shutdown does not complete with the child alive. Windows keeps its existing process-tree termination behavior.

## How to verify

```bash
go test ./...
go test -race ./...
go vet ./...
```

Closes #520

<sub>The leader left early; shutdown stayed for the rest of the group.</sub>
