### PR TITLE
feat: open selected process URL in browser

### DIFF
--- a/src/tui/actions.go
+++ b/src/tui/actions.go
@@ -48,6 +48,7 @@ const (
 	ActionDependencyGraph  = ActionName("dependency_graph")
 	ActionNamespaceOps     = ActionName("namespace_ops")
 	ActionCommandPalette   = ActionName("command_palette")
+	ActionProcOpenURL      = ActionName("open_url")
 )
 
 var defaultShortcuts = map[ActionName]tcell.Key{
@@ -84,6 +85,7 @@ var defaultShortcuts = map[ActionName]tcell.Key{
 	ActionLogPrettyPrint:   tcell.KeyRune,
 	ActionNamespaceOps:     tcell.KeyRune,
 	ActionCommandPalette:   tcell.KeyRune,
+	ActionProcOpenURL:      tcell.KeyRune,
 }
 
 var defaultShortcutsRunes = map[ActionName]rune{
@@ -92,6 +94,7 @@ var defaultShortcutsRunes = map[ActionName]rune{
 	ActionLogPrettyPrint: 'p',
 	ActionNamespaceOps:   'n',
 	ActionCommandPalette: ':',
+	ActionProcOpenURL:    'o',
 }
 
 var generalActionsOrder = []ActionName{
@@ -117,6 +120,7 @@ var procActionsOrder = []ActionName{
 	ActionProcFilter,
 	ActionProcessScale,
 	ActionProcessInfo,
+	ActionProcOpenURL,
 	ActionProcessSignal,
 	ActionProcessStart,
 	ActionProcessScreen,
@@ -443,6 +447,9 @@ func newShortCuts() *ShortCuts {
 			},
 			ActionCommandPalette: {
 				Description: "Command Palette",
+			},
+			ActionProcOpenURL: {
+				Description: "Open in Browser",
 			},
 		},
 	}

--- a/src/tui/process_url.go
+++ b/src/tui/process_url.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/f1bonacc1/process-compose/src/health"
+	"github.com/f1bonacc1/process-compose/src/types"
+)
+
+// deriveProcessURL builds a browser-openable URL for a process, using (in order):
+//  1. The process's http_get readiness probe (scheme://host:port/path). An empty
+//     host defaults to 127.0.0.1 and an empty scheme defaults to http.
+//  2. The first discovered TCP port -> http://127.0.0.1:<port>/.
+//
+// It returns ok=false when neither source yields a usable URL.
+func deriveProcessURL(cfg *types.ProcessConfig, ports *types.ProcessPorts) (string, bool) {
+	if cfg != nil && cfg.ReadinessProbe != nil && cfg.ReadinessProbe.HttpGet != nil {
+		if url, ok := urlFromHttpGet(cfg.ReadinessProbe.HttpGet); ok {
+			return url, true
+		}
+	}
+
+	if ports != nil && len(ports.TcpPorts) > 0 {
+		return fmt.Sprintf("http://127.0.0.1:%d/", ports.TcpPorts[0]), true
+	}
+
+	return "", false
+}
+
+func urlFromHttpGet(h *health.HttpProbe) (string, bool) {
+	port := h.NumPort
+	if port == 0 && h.Port != "" {
+		port, _ = strconv.Atoi(h.Port)
+	}
+	if port < 1 || port > 65535 {
+		return "", false
+	}
+
+	scheme := h.Scheme
+	if strings.TrimSpace(scheme) == "" {
+		scheme = "http"
+	}
+	host := h.Host
+	if strings.TrimSpace(host) == "" {
+		host = "127.0.0.1"
+	}
+	path := h.Path
+	if strings.TrimSpace(path) == "" {
+		path = "/"
+	} else if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	return fmt.Sprintf("%s://%s:%d%s", scheme, host, port, path), true
+}

--- a/src/tui/process_url_test.go
+++ b/src/tui/process_url_test.go
@@ -1,0 +1,86 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/f1bonacc1/process-compose/src/health"
+	"github.com/f1bonacc1/process-compose/src/types"
+)
+
+func httpGetConfig(h *health.HttpProbe) *types.ProcessConfig {
+	return &types.ProcessConfig{
+		ReadinessProbe: &health.Probe{HttpGet: h},
+	}
+}
+
+func TestDeriveProcessURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *types.ProcessConfig
+		ports   *types.ProcessPorts
+		wantURL string
+		wantOk  bool
+	}{
+		{
+			name:    "http_get with path",
+			cfg:     httpGetConfig(&health.HttpProbe{Host: "localhost", NumPort: 8080, Path: "/health"}),
+			wantURL: "http://localhost:8080/health",
+			wantOk:  true,
+		},
+		{
+			name:    "http_get without path defaults to /",
+			cfg:     httpGetConfig(&health.HttpProbe{Host: "localhost", NumPort: 8080}),
+			wantURL: "http://localhost:8080/",
+			wantOk:  true,
+		},
+		{
+			name:    "custom scheme host port",
+			cfg:     httpGetConfig(&health.HttpProbe{Scheme: "https", Host: "example.com", NumPort: 9443, Path: "/status"}),
+			wantURL: "https://example.com:9443/status",
+			wantOk:  true,
+		},
+		{
+			name:    "empty host defaults to 127.0.0.1",
+			cfg:     httpGetConfig(&health.HttpProbe{NumPort: 3000}),
+			wantURL: "http://127.0.0.1:3000/",
+			wantOk:  true,
+		},
+		{
+			name:    "port from string field",
+			cfg:     httpGetConfig(&health.HttpProbe{Host: "localhost", Port: "8081"}),
+			wantURL: "http://localhost:8081/",
+			wantOk:  true,
+		},
+		{
+			name:    "fallback to first tcp port",
+			cfg:     &types.ProcessConfig{},
+			ports:   &types.ProcessPorts{TcpPorts: []uint16{5000, 5001}},
+			wantURL: "http://127.0.0.1:5000/",
+			wantOk:  true,
+		},
+		{
+			name:   "neither http_get nor ports",
+			cfg:    &types.ProcessConfig{},
+			wantOk: false,
+		},
+		{
+			name:    "http_get without usable port falls back to tcp port",
+			cfg:     httpGetConfig(&health.HttpProbe{Host: "localhost"}),
+			ports:   &types.ProcessPorts{TcpPorts: []uint16{6000}},
+			wantURL: "http://127.0.0.1:6000/",
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotOk := deriveProcessURL(tt.cfg, tt.ports)
+			if gotOk != tt.wantOk {
+				t.Fatalf("ok = %v, want %v", gotOk, tt.wantOk)
+			}
+			if gotURL != tt.wantURL {
+				t.Errorf("url = %q, want %q", gotURL, tt.wantURL)
+			}
+		})
+	}
+}

--- a/src/tui/view.go
+++ b/src/tui/view.go
@@ -247,6 +247,7 @@ func (pv *pcView) setShortCutsActions() {
 	})
 	pv.shortcuts.setAction(ActionProcessScale, pv.showScale)
 	pv.shortcuts.setAction(ActionProcessInfo, pv.showInfo)
+	pv.shortcuts.setAction(ActionProcOpenURL, pv.openProcessURL)
 	if len(availableSignalOptions()) > 0 {
 		pv.shortcuts.setAction(ActionProcessSignal, pv.showSignalDialog)
 	}
@@ -465,6 +466,22 @@ func (pv *pcView) showInfo() {
 	ports, _ := pv.project.GetProcessPorts(name)
 	form := pv.createProcInfoForm(info, state, ports)
 	pv.showDialog(form, 0, 5+form.GetFormItemCount()*2)
+}
+
+func (pv *pcView) openProcessURL() {
+	name := pv.getSelectedProcName()
+	info, err := pv.project.GetProcessInfo(name)
+	if err != nil {
+		pv.showError(err.Error())
+		return
+	}
+	ports, _ := pv.project.GetProcessPorts(name)
+	url, ok := deriveProcessURL(info, ports)
+	if !ok {
+		pv.showError(fmt.Sprintf("No URL available for process '%s'", name))
+		return
+	}
+	openBrowser(url)
 }
 
 func (pv *pcView) showGraphDialog() {

--- a/www/docs/tui.md
+++ b/www/docs/tui.md
@@ -10,6 +10,7 @@ TUI Allows you to:
 - Edit processes' configuration
 - Review process dependency graph (`Ctrl+Q`)
 - Command palette for quick actions (`:`)
+- Open the selected process in a web browser (`o`)
 
 TUI is the default run mode, but it's possible to disable it:
 
@@ -68,6 +69,15 @@ Available commands:
 **Delete Process** removes the process from the running project. It will refuse to delete a process that other processes depend on. The process is not removed from `process-compose.yaml`.
 
 Multi-step commands support `Esc` to go back to the previous step.
+
+## Open in Browser
+
+Press `o` to open the selected process in your default web browser. The URL is derived, in order:
+
+1. From the process's `readiness_probe.http_get` (`scheme://host:port/path`). An empty host defaults to `127.0.0.1` and an empty scheme defaults to `http`.
+2. Otherwise, from the first discovered TCP port of the process (`http://127.0.0.1:<port>/`).
+
+If neither is available, a non-fatal error is shown and nothing is opened.
 
 ## Shortcuts Configuration
 


### PR DESCRIPTION
# PR Draft

## Title

feat: open selected process URL in a web browser

## Description

### What

Adds a TUI shortcut (`o`) that opens the currently selected process in the
user's default web browser.

### Why

Many processes managed by process-compose expose an HTTP endpoint (a web app,
an API, a dashboard). Today a user has to read the process's port from the Info
dialog and type the URL into a browser manually. This adds a one-key jump from
the process table straight to the running service.

### How the URL is derived

The URL for the selected process is derived, in order:

1. **Primary:** from the process's `readiness_probe.http_get`
   (`scheme://host:port/path`). An empty host defaults to `127.0.0.1` and an
   empty scheme defaults to `http`; an empty path defaults to `/`.
2. **Fallback:** if there is no usable `http_get` readiness probe, the first
   discovered TCP port from the process's live ports is used:
   `http://127.0.0.1:<port>/`.
3. If neither is available, nothing is opened and a non-fatal error is shown in
   the TUI (via the existing `showError` path).

The derivation lives in a small pure helper, `deriveProcessURL(cfg, ports)`, in
`src/tui/process_url.go`, so it is unit-testable in isolation. The handler
`openProcessURL` in `src/tui/view.go` fetches the selected process's config and
ports (the same data the Info dialog already uses) and calls the existing
`openBrowser` helper.

### Deliberate scoping: no new config field

This intentionally builds only on existing data (`readiness_probe.http_get` and
live TCP ports). It does **not** add a new per-process config field (e.g. a
`url:` field). A dedicated URL config field can be a later, separate PR; keeping
this one lean avoids introducing new schema/validation surface.

### Key binding

Bound to the rune `o` ("open"). It was verified free: the only existing rune
shortcuts are `/`, `m`, `p`, `n`, and `:`, and no other input capture consumes
`o`. It follows the same plain-letter-rune pattern as the existing `m`/`p`/`n`
shortcuts and is user-overridable via `shortcuts.yaml` (`open_url` action). The
action is added to `procActionsOrder` so it appears in the process action row
and command help.

### Testing notes

- New table-driven unit test `TestDeriveProcessURL` in
  `src/tui/process_url_test.go` covers: http_get with path, http_get without
  path (defaults to `/`), custom scheme/host/port, empty host -> `127.0.0.1`,
  port supplied via the string `port` field, fallback to first TCP port,
  neither source available (`ok == false`), and http_get with no usable port
  falling back to a TCP port.
- `go build ./...` passes.
- `go test ./src/tui/... ./src/health/...` passes.
- `gofmt` and `go vet ./src/tui/...` are clean.

### Docs

`www/docs/tui.md` documents the new `o` shortcut in the capabilities list and a
new "Open in Browser" section describing the derivation order.

## How to review

```
git diff main...feat/tui-open-browser
```
