### PR TITLE
 feat(completion): dynamic process-name completion for run/up and process start/stop/restart

### DIFF
--- a/src/cmd/completion_process.go
+++ b/src/cmd/completion_process.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/f1bonacc1/process-compose/src/loader"
+	"github.com/spf13/cobra"
+)
+
+// completionEntry formats a process name and its optional description as a
+// cobra completion candidate.
+func completionEntry(name, description string) string {
+	if desc, _, _ := strings.Cut(description, "\n"); desc != "" {
+		// cobra expects "name\tdescription". We replace tabs with spaces in the
+		// description. cobra doesn't currently care about tabs beyond the
+		// first, but spaces are shorter and zsh converts such tabs into `:`s.
+		return name + "\t" + strings.ReplaceAll(desc, "\t", " ")
+	}
+	return name
+}
+
+// completeProcessNamesFromConfig returns a cobra completion function that
+// completes process names by loading the config file(s), without a running
+// server. Used by commands that start their own server (run, up).
+//
+// For processes that have configured descriptions, the names come concatenated
+// with the first line of the descriptions in the cobra-appropriate
+// "name\tdescription" format.
+//
+// When single is true (e.g. `run`, which takes exactly one PROCESS), it stops
+// offering candidates once a positional arg is already present.
+func completeProcessNamesFromConfig(single bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if single && len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// Avoid aborting or printing errors for e.g. unparseable YAML config
+		opts.IsInternalLoader = true
+		project, err := loader.Load(opts)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		names, err := project.GetLexicographicProcessNames()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		comps := make([]string, len(names))
+		for i, name := range names {
+			comps[i] = completionEntry(name, project.Processes[name].Description)
+		}
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// completeProcessNamesFromServer returns a cobra completion function that
+// completes process names from a running process-compose server. Used by the
+// `process` subcommands (start/stop/restart), which act on a live project; this
+// also surfaces dynamically scaled replica names.
+func completeProcessNamesFromServer(single bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if single && len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// Names only, no descriptions. TODO: consider adding process
+		// descriptions to the server's `/processes` response.
+		names, err := getClient().GetLexicographicProcessNames()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/src/cmd/completion_process.go
+++ b/src/cmd/completion_process.go
@@ -57,9 +57,14 @@ func completeProcessNamesFromConfig(single bool) func(*cobra.Command, []string, 
 // `process` subcommands (start/stop/restart), which act on a live project; this
 // also surfaces dynamically scaled replica names.
 func completeProcessNamesFromServer(single bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		if single && len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// Normally done in PersistentPreRun so that --unix-socket implies -U; but
+		// during completion PreRun runs before flag parsing, so we must do it here.
+		if isUnixSocketMode(cmd) {
+			*pcFlags.IsUnixSocket = true
 		}
 		// Names only, no descriptions. TODO: consider adding process
 		// descriptions to the server's `/processes` response.

--- a/src/cmd/completion_process_test.go
+++ b/src/cmd/completion_process_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/f1bonacc1/process-compose/src/loader"
+	"github.com/spf13/cobra"
+)
+
+const completionValidConfig = `version: "0.5"
+processes:
+  postgres:
+    command: "echo postgres"
+    description: "the database"
+  redis:
+    command: "echo redis"
+  minio:
+    command: "echo minio"
+`
+
+const completionUnclosedBraceConfig = `version: "0.5"
+processes:
+  postgres:
+    command: "echo ${UNCLOSED_BRACE"
+`
+
+func writeCompletionConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "process-compose.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return path
+}
+
+func TestCompleteProcessNamesFromConfig(t *testing.T) {
+	// The helper reads the package-global opts; restore it after the test.
+	orig := opts
+	t.Cleanup(func() { opts = orig })
+
+	setConfig := func(t *testing.T, content string) {
+		opts = &loader.LoaderOptions{FileNames: []string{writeCompletionConfig(t, content)}}
+	}
+
+	t.Run("returns names and descriptions in lexicographic order", func(t *testing.T) {
+		setConfig(t, completionValidConfig)
+		got, directive := completeProcessNamesFromConfig(true)(nil, nil, "")
+		if want := []string{"minio", "postgres\tthe database", "redis"}; !slices.Equal(got, want) {
+			t.Errorf("names = %v, want %v", got, want)
+		}
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %d, want NoFileComp (%d)", directive, cobra.ShellCompDirectiveNoFileComp)
+		}
+	})
+
+	t.Run("single stops offering names once an arg is present", func(t *testing.T) {
+		setConfig(t, completionValidConfig)
+		got, directive := completeProcessNamesFromConfig(true)(nil, []string{"postgres"}, "")
+		if len(got) != 0 {
+			t.Errorf("names = %v, want none after first positional arg", got)
+		}
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %d, want NoFileComp", directive)
+		}
+	})
+
+	t.Run("non-single completes at every position", func(t *testing.T) {
+		setConfig(t, completionValidConfig)
+		got, _ := completeProcessNamesFromConfig(false)(nil, []string{"postgres"}, "")
+		if len(got) != 3 {
+			t.Errorf("names = %v, want all 3 names for a variadic command", got)
+		}
+	})
+
+	t.Run("broken config yields no candidates instead of exiting", func(t *testing.T) {
+		// completionUnclosedBraceConfig triggers an envsubst "missing closing
+		// brace" error, which is fatal (and would abort the whole test binary)
+		// *unless* completeProcessNamesFromConfig properly sets the
+		// IsInternalLoader option.
+		setConfig(t, completionUnclosedBraceConfig)
+		got, directive := completeProcessNamesFromConfig(true)(nil, nil, "")
+		if len(got) != 0 {
+			t.Errorf("names = %v, want none on a broken config", got)
+		}
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("directive = %d, want NoFileComp", directive)
+		}
+	})
+}
+
+func TestCompletionEntry(t *testing.T) {
+	tests := []struct {
+		name, description, want string
+	}{
+		{"web", "", "web"},
+		{"web", "a server", "web\ta server"},
+		{"web", "first line\nsecond line", "web\tfirst line"},
+		{"web", "has\ttab", "web\thas tab"},
+	}
+	for _, tt := range tests {
+		if got := completionEntry(tt.name, tt.description); got != tt.want {
+			t.Errorf("completionEntry(%q, %q) = %q, want %q", tt.name, tt.description, got, tt.want)
+		}
+	}
+}

--- a/src/cmd/completion_process_test.go
+++ b/src/cmd/completion_process_test.go
@@ -1,12 +1,19 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
+	"github.com/f1bonacc1/process-compose/src/config"
 	"github.com/f1bonacc1/process-compose/src/loader"
+	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/spf13/cobra"
 )
 
@@ -104,5 +111,77 @@ func TestCompletionEntry(t *testing.T) {
 		if got := completionEntry(tt.name, tt.description); got != tt.want {
 			t.Errorf("completionEntry(%q, %q) = %q, want %q", tt.name, tt.description, got, tt.want)
 		}
+	}
+}
+
+// Tests that `--unix-socket` implies `-U` even in the context of completions.
+//
+// This very particular usecase requires a special workaround in
+// `completeProcessNamesFromServer` to work correctly. Without it, completion
+// would still work correctly for `process-compose -U --unix-socket blah process
+// start <TAB>` or `PC_SOCKET_PATH=blah process-compose ...`, but it would
+// surprisingly not work for just `process-compose --unix-socket blah ...`.
+//
+// While few people are likely to use process name completion with
+// `--unix-socket`, they would be really confused if we didn't implement such a
+// workaround, since they'd be used to `--unix-socket` implying `-U` in all
+// other situations.
+func TestProcessStopCompletionOverUnixSocketFlag(t *testing.T) {
+	// Fake server on a unix socket.
+	//
+	// We must keep the path short. For example, on macOS, the cap on `sun_path`
+	// is 104 bytes, so process-compose would fail to bind to a socket with a
+	// longer path. By an unfortunate coincidence, macOS also has particularly
+	// long temporary dir names; t.TempDir() results in long paths along the
+	// lines of `/var/folders/<2 chars>/<~30-char hash>/T/test_name.suffix/001`
+	dir, err := os.MkdirTemp("", "pc") //nolint:usetesting // t.TempDir() path too long on e.g. macOS (see above)
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/processes", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(types.ProcessesState{States: []types.ProcessState{
+			{Name: "web"}, {Name: "db"},
+		}})
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// UDS must come from the flag, not the PC_SOCKET_PATH env var, for the
+	// failure-prone version of the scenario
+	t.Setenv(config.EnvVarUnixSocketPath, "")
+
+	// Execute mutates process-wide state; restore it.
+	origUDS, origPath, origLog := *pcFlags.IsUnixSocket, *pcFlags.UnixSocketPath, *pcFlags.LogFile
+	origCheck := config.CheckForUpdates
+	t.Cleanup(func() {
+		*pcFlags.IsUnixSocket, *pcFlags.UnixSocketPath, *pcFlags.LogFile = origUDS, origPath, origLog
+		config.CheckForUpdates = origCheck
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	*pcFlags.IsUnixSocket = false
+	config.CheckForUpdates = "false"                // PreRun would otherwise hit the network
+	*pcFlags.LogFile = filepath.Join(dir, "pc.log") // keep PreRun's setupLogger out of the real log
+
+	var out, errb bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&errb)
+	rootCmd.SetArgs([]string{"__complete", "process", "stop", "--unix-socket", sock, ""})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute __complete: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "db") || !strings.Contains(got, "web") {
+		t.Errorf("completion output = %q; want it to list db and web (UDS via --unix-socket honored)", got)
 	}
 }

--- a/src/cmd/restart.go
+++ b/src/cmd/restart.go
@@ -23,4 +23,5 @@ var restartCmd = &cobra.Command{
 
 func init() {
 	processCmd.AddCommand(restartCmd)
+	restartCmd.ValidArgsFunction = completeProcessNamesFromServer(true)
 }

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -46,6 +46,7 @@ Command line arguments, provided after --, are passed to the PROCESS.`,
 
 func init() {
 	rootCmd.AddCommand(runCmd)
+	runCmd.ValidArgsFunction = completeProcessNamesFromConfig(true)
 
 	runCmd.Flags().BoolVarP(pcFlags.NoDependencies, "no-deps", "", *pcFlags.NoDependencies, "don't start dependent processes")
 	runCmd.Flags().AddFlag(rootCmd.Flags().Lookup("config"))

--- a/src/cmd/start.go
+++ b/src/cmd/start.go
@@ -24,4 +24,5 @@ var startCmd = &cobra.Command{
 
 func init() {
 	processCmd.AddCommand(startCmd)
+	startCmd.ValidArgsFunction = completeProcessNamesFromServer(true)
 }

--- a/src/cmd/stop.go
+++ b/src/cmd/stop.go
@@ -78,5 +78,6 @@ func prepareConciseOutput(stopped map[string]string, processes []string) (string
 
 func init() {
 	processCmd.AddCommand(stopCmd)
+	stopCmd.ValidArgsFunction = completeProcessNamesFromServer(false)
 	stopCmd.Flags().BoolVarP(&stopVerboseOutput, "verbose", "v", stopVerboseOutput, "verbose output")
 }

--- a/src/cmd/up.go
+++ b/src/cmd/up.go
@@ -21,6 +21,7 @@ will start them and their dependencies only`,
 
 func init() {
 	rootCmd.AddCommand(upCmd)
+	upCmd.ValidArgsFunction = completeProcessNamesFromConfig(false)
 
 	nsAdmitter := &admitter.NamespaceAdmitter{}
 	opts.AddAdmitter(nsAdmitter)

--- a/src/loader/loader.go
+++ b/src/loader/loader.go
@@ -168,8 +168,10 @@ func loadProjectFromFile(inputFile string, opts *LoaderOptions) (*types.Project,
 	temp := strings.ReplaceAll(string(yamlFile), "$$", envEscaped)
 	temp, err = envsubst.Eval(temp, expanderFn)
 	if err != nil {
+		if opts.IsInternalLoader {
+			return nil, err
+		}
 		log.Fatal().Err(err).Msgf("Failed to parse %s, environment substitution errored.", inputFile)
-		return nil, err
 	}
 	temp = strings.ReplaceAll(temp, envEscaped, "$")
 


### PR DESCRIPTION
Add shell completion to process-name-taking commands such as
`process-compose run <TAB>`. Uses cobra's `ValidArgsFunction`
functionality. Should work in every supported shell.

`run` and `up` load names from the config file, which also allows them
to pass the first line of the process descriptions (if defined in the
config) to `cobra` together with the names.

The `process start/stop/restart` commands query the running server.
The server doesn't currently return the process descriptions (this could
be added relatively easily), so the completions will come without
descriptions. 

On any error (missing config or unreachable server) the helpers return
ShellCompDirectiveNoFileComp with no candidates. The config path sets
IsInternalLoader so a malformed or half-edited config returns an error
instead of aborting completion via log.Fatal.

-----

## About the third commit, `honor --unix-socket ...`

That is a preventive fix to a somewhat obscure but really confusing problem
discovered by AI. See the description and the code for details. It comes with
a somewhat heavy-weight AI-generated test to prove that the bug actually exists.

I'm happy to remove that commit if you prefer a different solution, or to
keep the fix and remove the heavy-weight (but IMO easy-to-follow) test.

One potentially better solution IMO would be to remove the `-U` flag entirely, I'm not
sure it's useful when `--unix-socket` implies `-U` but a bare `-U` creates
a socket at a hard-to-guess path.
