### PR TITLE
Fix swagger host for configured api server address and port

### DIFF
--- a/src/api/server.go
+++ b/src/api/server.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/f1bonacc1/process-compose/src/app"
+	"github.com/f1bonacc1/process-compose/src/docs"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
 )
@@ -55,6 +56,9 @@ func StartHttpServerWithTCP(useLogger bool, address string, port int, project ap
 		Addr:    endPoint,
 		Handler: router.Handler(),
 	}
+
+	// Update swagger address and port dynamically based on the provided address and port
+	docs.SwaggerInfo.Host = fmt.Sprintf("%s:%d", address, port)
 
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
## Bug Fix: Swagger Host Not Updated with Dynamic Address and Port

When the server starts with a custom port (via CLI flag `-p` or `PC_PORT_NUM` environment variable), the Swagger documentation should reflect the actual server address and port instead of showing the hardcoded default `localhost:8080`.

## Problem

Currently, the interactive Swagger UI at `/swagger/index.html` always shows `localhost:8080` as the host, even when the server is running on a different port or address configured through:
- CLI flag: `process-compose -p 9090`
- Environment variable: `PC_PORT_NUM=9090 process-compose`

This causes the Swagger UI to fail to communicate with the API when using non-standard ports.

## Solution

Update the `SwaggerInfo.Host` dynamically in the `StartHttpServerWithTCP()` function before the router is created. The `SwaggerInfo` variable is already exported and designed to be modified at runtime (as indicated by its comment: "holds exported Swagger Info so clients can modify it").

## Changes Required

Modify `src/api/server.go`:

1. Import the `docs` package
2. Add code to update `docs.SwaggerInfo.Host` with the actual address and port in `StartHttpServerWithTCP()` function

## Implementation Details

- Add import: `"github.com/f1bonacc1/process-compose/src/docs"`
- In `StartHttpServerWithTCP()`, add at the beginning (before `router := getRouter(...)`):
  
```go
docs.SwaggerInfo.Host = fmt.Sprintf("%s:%d", address, port)
```